### PR TITLE
Add trade history and activity log

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ curl http://localhost:8080/api/v1/portfolios/1ddb1c1c-827f-4bf0-b85a-3d5786c3b26
 ```
 
 ```bash
+curl "http://localhost:8080/api/v1/orders?wallet_id=1ddb1c1c-827f-4bf0-b85a-3d5786c3b26c"
+```
+
+```bash
+curl "http://localhost:8080/api/v1/activity?wallet_id=1ddb1c1c-827f-4bf0-b85a-3d5786c3b26c"
+```
+
+```bash
 curl -X POST http://localhost:8080/api/v1/orders \
   -H "Content-Type: application/json" \
   -d '{

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aidun/tradelab/backend/internal/config"
 	httpapi "github.com/aidun/tradelab/backend/internal/http"
+	historyservice "github.com/aidun/tradelab/backend/internal/service/history"
 	marketservice "github.com/aidun/tradelab/backend/internal/service/market"
 	orderservice "github.com/aidun/tradelab/backend/internal/service/order"
 	portfolioservice "github.com/aidun/tradelab/backend/internal/service/portfolio"
@@ -28,10 +29,10 @@ func main() {
 	marketService := marketservice.NewService(marketRepository)
 	orderService := orderservice.NewService(marketRepository, balanceRepository, portfolioRepository)
 	portfolioService := portfolioservice.NewService(portfolioRepository)
-
+	historyService := historyservice.NewService(portfolioRepository)
 	server := &http.Server{
 		Addr:    cfg.HTTPAddress,
-		Handler: httpapi.NewRouter(marketService, orderService, portfolioService),
+		Handler: httpapi.NewRouter(marketService, orderService, portfolioService, historyService, historyService),
 	}
 
 	log.Printf("TradeLab backend listening on %s", cfg.HTTPAddress)

--- a/backend/internal/domain/order.go
+++ b/backend/internal/domain/order.go
@@ -34,26 +34,26 @@ type Order struct {
 }
 
 type Balance struct {
-	WalletID     string
+	WalletID    string
 	AssetSymbol string
 	Available   float64
 }
 
 type Position struct {
-	ID             string
-	UserID         string
-	WalletID       string
-	MarketID       string
-	MarketSymbol   string
-	BaseAsset      string
-	QuoteAsset     string
-	Status         string
-	EntryQuantity  float64
-	EntryPriceAvg  float64
-	CurrentPrice   float64
-	PositionValue  float64
-	UnrealizedPnL  float64
-	OpenedAt       time.Time
+	ID            string
+	UserID        string
+	WalletID      string
+	MarketID      string
+	MarketSymbol  string
+	BaseAsset     string
+	QuoteAsset    string
+	Status        string
+	EntryQuantity float64
+	EntryPriceAvg float64
+	CurrentPrice  float64
+	PositionValue float64
+	UnrealizedPnL float64
+	OpenedAt      time.Time
 }
 
 type PortfolioSummary struct {
@@ -63,4 +63,13 @@ type PortfolioSummary struct {
 	CashBalance  float64
 	Positions    []Position
 	Balances     []Balance
+}
+
+type ActivityLog struct {
+	ID        string
+	WalletID  string
+	LogType   string
+	Title     string
+	Message   string
+	CreatedAt time.Time
 }

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/aidun/tradelab/backend/internal/domain"
@@ -23,7 +24,15 @@ type PortfolioGetter interface {
 	GetSummary(ctx context.Context, walletID string) (domain.PortfolioSummary, error)
 }
 
-func NewRouter(markets MarketLister, orders OrderPlacer, portfolios PortfolioGetter) http.Handler {
+type OrderHistoryLister interface {
+	ListOrders(ctx context.Context, walletID string, limit int) ([]domain.Order, error)
+}
+
+type ActivityHistoryLister interface {
+	ListActivity(ctx context.Context, walletID string, limit int) ([]domain.ActivityLog, error)
+}
+
+func NewRouter(markets MarketLister, orders OrderPlacer, portfolios PortfolioGetter, orderHistory OrderHistoryLister, activityHistory ActivityHistoryLister) http.Handler {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
@@ -40,9 +49,7 @@ func NewRouter(markets MarketLister, orders OrderPlacer, portfolios PortfolioGet
 			return
 		}
 
-		writeJSON(w, http.StatusOK, map[string]any{
-			"markets": items,
-		})
+		writeJSON(w, http.StatusOK, map[string]any{"markets": items})
 	})
 
 	mux.HandleFunc("GET /api/v1/portfolios/", func(w http.ResponseWriter, r *http.Request) {
@@ -58,9 +65,39 @@ func NewRouter(markets MarketLister, orders OrderPlacer, portfolios PortfolioGet
 			return
 		}
 
-		writeJSON(w, http.StatusOK, map[string]any{
-			"portfolio": summary,
-		})
+		writeJSON(w, http.StatusOK, map[string]any{"portfolio": summary})
+	})
+
+	mux.HandleFunc("GET /api/v1/orders", func(w http.ResponseWriter, r *http.Request) {
+		walletID := r.URL.Query().Get("wallet_id")
+		if walletID == "" {
+			writeError(w, http.StatusBadRequest, "wallet_id is required")
+			return
+		}
+
+		items, err := orderHistory.ListOrders(r.Context(), walletID, parseLimit(r.URL.Query().Get("limit")))
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to load orders")
+			return
+		}
+
+		writeJSON(w, http.StatusOK, map[string]any{"orders": items})
+	})
+
+	mux.HandleFunc("GET /api/v1/activity", func(w http.ResponseWriter, r *http.Request) {
+		walletID := r.URL.Query().Get("wallet_id")
+		if walletID == "" {
+			writeError(w, http.StatusBadRequest, "wallet_id is required")
+			return
+		}
+
+		items, err := activityHistory.ListActivity(r.Context(), walletID, parseLimit(r.URL.Query().Get("limit")))
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to load activity")
+			return
+		}
+
+		writeJSON(w, http.StatusOK, map[string]any{"activity": items})
 	})
 
 	mux.HandleFunc("POST /api/v1/orders", func(w http.ResponseWriter, r *http.Request) {
@@ -98,12 +135,21 @@ func NewRouter(markets MarketLister, orders OrderPlacer, portfolios PortfolioGet
 			return
 		}
 
-		writeJSON(w, http.StatusCreated, map[string]any{
-			"order": order,
-		})
+		writeJSON(w, http.StatusCreated, map[string]any{"order": order})
 	})
 
 	return mux
+}
+
+func parseLimit(raw string) int {
+	if raw == "" {
+		return 10
+	}
+	limit, err := strconv.Atoi(raw)
+	if err != nil || limit <= 0 || limit > 100 {
+		return 10
+	}
+	return limit
 }
 
 func writeJSON(w http.ResponseWriter, statusCode int, payload any) {
@@ -113,7 +159,5 @@ func writeJSON(w http.ResponseWriter, statusCode int, payload any) {
 }
 
 func writeError(w http.ResponseWriter, statusCode int, message string) {
-	writeJSON(w, statusCode, map[string]string{
-		"error": message,
-	})
+	writeJSON(w, statusCode, map[string]string{"error": message})
 }

--- a/backend/internal/http/router_test.go
+++ b/backend/internal/http/router_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aidun/tradelab/backend/internal/domain"
 	orderservice "github.com/aidun/tradelab/backend/internal/service/order"
@@ -16,7 +17,7 @@ func TestHealthRoute(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	recorder := httptest.NewRecorder()
 
-	NewRouter(fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}).ServeHTTP(recorder, req)
+	NewRouter(fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", recorder.Code)
@@ -31,14 +32,10 @@ func TestListMarketsRoute(t *testing.T) {
 		markets: []domain.Market{
 			{ID: "market-1", Symbol: "XRP/USDT", BaseAsset: "XRP", QuoteAsset: "USDT", Exchange: "demo"},
 		},
-	}, fakeOrderPlacer{}, fakePortfolioGetter{}).ServeHTTP(recorder, req)
+	}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", recorder.Code)
-	}
-
-	if body := recorder.Body.String(); !strings.Contains(body, "XRP/USDT") {
-		t.Fatalf("expected market symbol in response body, got %s", body)
 	}
 }
 
@@ -47,19 +44,41 @@ func TestPortfolioRoute(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
 	NewRouter(fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{
-		summary: domain.PortfolioSummary{
-			WalletID:     "wallet-1",
-			BaseCurrency: "USDT",
-			TotalValue:   10000,
-		},
-	}).ServeHTTP(recorder, req)
+		summary: domain.PortfolioSummary{WalletID: "wallet-1", BaseCurrency: "USDT", TotalValue: 10000},
+	}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", recorder.Code)
+	}
+}
+
+func TestListOrdersRoute(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/orders?wallet_id=wallet-1", nil)
+	recorder := httptest.NewRecorder()
+
+	NewRouter(fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{
+		orders: []domain.Order{{ID: "order-1", WalletID: "wallet-1", MarketSymbol: "XRP/USDT"}},
+	}, fakeActivityHistoryLister{}).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", recorder.Code)
 	}
 
-	if body := recorder.Body.String(); !strings.Contains(body, "wallet-1") {
-		t.Fatalf("expected wallet ID in response body, got %s", body)
+	if !strings.Contains(recorder.Body.String(), "order-1") {
+		t.Fatalf("expected order payload in response, got %s", recorder.Body.String())
+	}
+}
+
+func TestListActivityRoute(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/activity?wallet_id=wallet-1", nil)
+	recorder := httptest.NewRecorder()
+
+	NewRouter(fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{
+		activity: []domain.ActivityLog{{ID: "log-1", WalletID: "wallet-1", Title: "Demo buy recorded", CreatedAt: time.Now()}},
+	}).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", recorder.Code)
 	}
 }
 
@@ -78,14 +97,10 @@ func TestCreateOrderRoute(t *testing.T) {
 			QuoteAmount:  50,
 			Status:       domain.OrderStatusFilled,
 		},
-	}, fakePortfolioGetter{}).ServeHTTP(recorder, req)
+	}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d", recorder.Code)
-	}
-
-	if body := recorder.Body.String(); !strings.Contains(body, "order-1") {
-		t.Fatalf("expected order ID in response body, got %s", body)
 	}
 }
 
@@ -94,9 +109,7 @@ type fakeMarketLister struct {
 	err     error
 }
 
-func (f fakeMarketLister) List(context.Context) ([]domain.Market, error) {
-	return f.markets, f.err
-}
+func (f fakeMarketLister) List(context.Context) ([]domain.Market, error) { return f.markets, f.err }
 
 type fakeOrderPlacer struct {
 	order domain.Order
@@ -114,4 +127,22 @@ type fakePortfolioGetter struct {
 
 func (f fakePortfolioGetter) GetSummary(context.Context, string) (domain.PortfolioSummary, error) {
 	return f.summary, f.err
+}
+
+type fakeOrderHistoryLister struct {
+	orders []domain.Order
+	err    error
+}
+
+func (f fakeOrderHistoryLister) ListOrders(context.Context, string, int) ([]domain.Order, error) {
+	return f.orders, f.err
+}
+
+type fakeActivityHistoryLister struct {
+	activity []domain.ActivityLog
+	err      error
+}
+
+func (f fakeActivityHistoryLister) ListActivity(context.Context, string, int) ([]domain.ActivityLog, error) {
+	return f.activity, f.err
 }

--- a/backend/internal/service/history/service.go
+++ b/backend/internal/service/history/service.go
@@ -1,0 +1,24 @@
+package history
+
+import (
+	"context"
+
+	"github.com/aidun/tradelab/backend/internal/domain"
+	"github.com/aidun/tradelab/backend/internal/store"
+)
+
+type Service struct {
+	orders store.PortfolioRepository
+}
+
+func NewService(orders store.PortfolioRepository) *Service {
+	return &Service{orders: orders}
+}
+
+func (s *Service) ListOrders(ctx context.Context, walletID string, limit int) ([]domain.Order, error) {
+	return s.orders.ListByWallet(ctx, walletID, limit)
+}
+
+func (s *Service) ListActivity(ctx context.Context, walletID string, limit int) ([]domain.ActivityLog, error) {
+	return s.orders.ListActivityByWallet(ctx, walletID, limit)
+}

--- a/backend/internal/service/order/service_test.go
+++ b/backend/internal/service/order/service_test.go
@@ -73,7 +73,7 @@ func TestPlaceMarketBuyReturnsErrorWhenFundsAreInsufficient(t *testing.T) {
 	}
 }
 
-func TestPlaceMarketBuyCreatesPendingOrder(t *testing.T) {
+func TestPlaceMarketBuyCreatesFilledOrder(t *testing.T) {
 	now := time.Date(2026, 3, 29, 12, 0, 0, 0, time.UTC)
 
 	service := NewService(
@@ -111,14 +111,6 @@ func TestPlaceMarketBuyCreatesPendingOrder(t *testing.T) {
 		t.Fatalf("expected filled status, got %s", order.Status)
 	}
 
-	if order.UserID != "user-1" {
-		t.Fatalf("expected user-1, got %s", order.UserID)
-	}
-
-	if order.MarketSymbol != "XRP/USDT" {
-		t.Fatalf("expected XRP/USDT market, got %s", order.MarketSymbol)
-	}
-
 	if order.BaseQuantity <= 0 {
 		t.Fatalf("expected positive base quantity, got %f", order.BaseQuantity)
 	}
@@ -128,18 +120,14 @@ func TestPlaceMarketBuyCreatesPendingOrder(t *testing.T) {
 	}
 }
 
-type fakeClock struct {
-	now time.Time
-}
+type fakeClock struct{ now time.Time }
 
-func (f fakeClock) Now() time.Time {
-	return f.now
-}
+func (f fakeClock) Now() time.Time { return f.now }
 
 type fakeMarketRepository struct {
 	markets []domain.Market
-	market domain.Market
-	err    error
+	market  domain.Market
+	err     error
 }
 
 func (f fakeMarketRepository) List(context.Context) ([]domain.Market, error) {
@@ -167,10 +155,17 @@ func (f fakePortfolioRepository) ApplyMarketBuy(_ context.Context, order domain.
 	if f.err != nil {
 		return domain.Order{}, f.err
 	}
-
 	return order, nil
 }
 
 func (f fakePortfolioRepository) GetSummary(context.Context, string) (domain.PortfolioSummary, error) {
 	return domain.PortfolioSummary{}, f.err
+}
+
+func (f fakePortfolioRepository) ListByWallet(context.Context, string, int) ([]domain.Order, error) {
+	return nil, f.err
+}
+
+func (f fakePortfolioRepository) ListActivityByWallet(context.Context, string, int) ([]domain.ActivityLog, error) {
+	return nil, f.err
 }

--- a/backend/internal/store/postgres/postgres.go
+++ b/backend/internal/store/postgres/postgres.go
@@ -37,13 +37,11 @@ func (r *MarketRepository) List(ctx context.Context) ([]domain.Market, error) {
 	defer rows.Close()
 
 	var markets []domain.Market
-
 	for rows.Next() {
 		var item domain.Market
 		if err := rows.Scan(&item.ID, &item.Symbol, &item.BaseAsset, &item.QuoteAsset, &item.MinNotional, &item.Exchange); err != nil {
 			return nil, err
 		}
-
 		markets = append(markets, item)
 	}
 
@@ -172,6 +170,21 @@ func (r *PortfolioRepository) ApplyMarketBuy(ctx context.Context, order domain.O
 		return domain.Order{}, err
 	}
 
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO activity_logs (
+			id,
+			user_id,
+			wallet_id,
+			order_id,
+			log_type,
+			title,
+			message,
+			created_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+	`, order.ID, order.UserID, order.WalletID, order.ID, "trade", "Demo buy recorded", "A demo market buy was created for "+order.MarketSymbol+".", order.CreatedAt); err != nil {
+		return domain.Order{}, err
+	}
+
 	if err := tx.Commit(); err != nil {
 		return domain.Order{}, err
 	}
@@ -201,12 +214,10 @@ func (r *PortfolioRepository) GetSummary(ctx context.Context, walletID string) (
 		if err := rows.Scan(&balance.WalletID, &balance.AssetSymbol, &balance.Available); err != nil {
 			return domain.PortfolioSummary{}, err
 		}
-
 		if balance.AssetSymbol == summary.BaseCurrency {
 			summary.CashBalance = balance.Available
 			summary.TotalValue += balance.Available
 		}
-
 		summary.Balances = append(summary.Balances, balance)
 	}
 
@@ -255,13 +266,93 @@ func (r *PortfolioRepository) GetSummary(ctx context.Context, walletID string) (
 
 		position.CurrentPrice = position.EntryPriceAvg
 		position.PositionValue = position.EntryQuantity * position.EntryPriceAvg
-		position.UnrealizedPnL = 0
-
 		summary.TotalValue += position.PositionValue
 		summary.Positions = append(summary.Positions, position)
 	}
 
 	return summary, nil
+}
+
+func (r *PortfolioRepository) ListByWallet(ctx context.Context, walletID string, limit int) ([]domain.Order, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT
+			o.id,
+			o.user_id,
+			o.wallet_id,
+			o.market_id,
+			m.symbol,
+			base_asset.symbol,
+			quote_asset.symbol,
+			COALESCE(o.requested_quote_amount, 0),
+			COALESCE(o.executed_quantity, 0),
+			COALESCE(o.average_execution_price, 0),
+			o.side,
+			o.order_type,
+			o.status,
+			o.submitted_at
+		FROM orders o
+		JOIN markets m ON m.id = o.market_id
+		JOIN assets base_asset ON base_asset.id = m.base_asset_id
+		JOIN assets quote_asset ON quote_asset.id = m.quote_asset_id
+		WHERE o.wallet_id = $1
+		ORDER BY o.submitted_at DESC
+		LIMIT $2
+	`, walletID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var items []domain.Order
+	for rows.Next() {
+		var item domain.Order
+		if err := rows.Scan(
+			&item.ID,
+			&item.UserID,
+			&item.WalletID,
+			&item.MarketID,
+			&item.MarketSymbol,
+			&item.BaseAsset,
+			&item.QuoteAsset,
+			&item.QuoteAmount,
+			&item.BaseQuantity,
+			&item.ExpectedPrice,
+			&item.Side,
+			&item.Type,
+			&item.Status,
+			&item.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+
+	return items, rows.Err()
+}
+
+func (r *PortfolioRepository) ListActivityByWallet(ctx context.Context, walletID string, limit int) ([]domain.ActivityLog, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, wallet_id, log_type, title, message, created_at
+		FROM activity_logs
+		WHERE wallet_id = $1
+		ORDER BY created_at DESC
+		LIMIT $2
+	`, walletID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var items []domain.ActivityLog
+	for rows.Next() {
+		var item domain.ActivityLog
+		if err := rows.Scan(&item.ID, &item.WalletID, &item.LogType, &item.Title, &item.Message, &item.CreatedAt); err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+
+	return items, rows.Err()
 }
 
 func (r *PortfolioRepository) Create(ctx context.Context, order domain.Order) (domain.Order, error) {

--- a/backend/internal/store/store.go
+++ b/backend/internal/store/store.go
@@ -17,9 +17,13 @@ type BalanceRepository interface {
 
 type OrderRepository interface {
 	Create(ctx context.Context, order domain.Order) (domain.Order, error)
+	ListByWallet(ctx context.Context, walletID string, limit int) ([]domain.Order, error)
+	ListActivityByWallet(ctx context.Context, walletID string, limit int) ([]domain.ActivityLog, error)
 }
 
 type PortfolioRepository interface {
 	ApplyMarketBuy(ctx context.Context, order domain.Order) (domain.Order, error)
 	GetSummary(ctx context.Context, walletID string) (domain.PortfolioSummary, error)
+	ListByWallet(ctx context.Context, walletID string, limit int) ([]domain.Order, error)
+	ListActivityByWallet(ctx context.Context, walletID string, limit int) ([]domain.ActivityLog, error)
 }

--- a/backend/migrations/000005_add_activity_logs.down.sql
+++ b/backend/migrations/000005_add_activity_logs.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS activity_logs_wallet_created_idx;
+DROP TABLE IF EXISTS activity_logs;

--- a/backend/migrations/000005_add_activity_logs.up.sql
+++ b/backend/migrations/000005_add_activity_logs.up.sql
@@ -1,0 +1,15 @@
+CREATE TABLE activity_logs (
+  id UUID PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES users(id),
+  wallet_id UUID REFERENCES wallets(id),
+  strategy_id UUID,
+  order_id UUID REFERENCES orders(id),
+  log_type TEXT NOT NULL,
+  title TEXT NOT NULL,
+  message TEXT NOT NULL,
+  metadata_json JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX activity_logs_wallet_created_idx
+  ON activity_logs (wallet_id, created_at DESC);

--- a/frontend/__tests__/home.test.tsx
+++ b/frontend/__tests__/home.test.tsx
@@ -26,6 +26,45 @@ describe("Hero", () => {
         );
       }
 
+      if (url.includes("/api/v1/orders")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              orders: [
+                {
+                  id: "order-1",
+                  walletID: "wallet-1",
+                  marketSymbol: "XRP/USDT",
+                  quoteAmount: 50,
+                  expectedPrice: 0.67,
+                  status: "filled",
+                  createdAt: "2026-03-29T12:00:00Z"
+                }
+              ]
+            })
+          )
+        );
+      }
+
+      if (url.includes("/api/v1/activity")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              activity: [
+                {
+                  id: "log-1",
+                  walletID: "wallet-1",
+                  logType: "trade",
+                  title: "Demo buy recorded",
+                  message: "A demo market buy was created for XRP/USDT.",
+                  createdAt: "2026-03-29T12:01:00Z"
+                }
+              ]
+            })
+          )
+        );
+      }
+
       return Promise.resolve(
         new Response(
           JSON.stringify({
@@ -63,5 +102,6 @@ describe("Hero", () => {
     });
 
     expect(screen.getByText(/run demo buy/i)).toBeInTheDocument();
+    expect(screen.getByText(/demo buy recorded/i)).toBeInTheDocument();
   });
 });

--- a/frontend/components/market-dashboard.tsx
+++ b/frontend/components/market-dashboard.tsx
@@ -1,7 +1,17 @@
 "use client";
 
 import React, { startTransition, useEffect, useState } from "react";
-import { fetchMarkets, fetchPortfolio, placeMarketBuy, type Market, type PortfolioSummary } from "@/lib/api";
+import {
+  fetchActivity,
+  fetchMarkets,
+  fetchOrders,
+  fetchPortfolio,
+  placeMarketBuy,
+  type ActivityLog,
+  type Market,
+  type Order,
+  type PortfolioSummary
+} from "@/lib/api";
 
 const DEMO_USER_ID = "cfbf7c8f-eaf9-47fa-8674-2a29fed1fcc9";
 const DEMO_WALLET_ID = "1ddb1c1c-827f-4bf0-b85a-3d5786c3b26c";
@@ -23,6 +33,8 @@ function formatNumber(value: number) {
 export function MarketDashboard() {
   const [markets, setMarkets] = useState<Market[]>([]);
   const [portfolio, setPortfolio] = useState<PortfolioSummary | null>(null);
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [activity, setActivity] = useState<ActivityLog[]>([]);
   const [selectedMarket, setSelectedMarket] = useState("XRP/USDT");
   const [quoteAmount, setQuoteAmount] = useState("50");
   const [expectedPrice, setExpectedPrice] = useState("0.67");
@@ -34,13 +46,17 @@ export function MarketDashboard() {
   async function loadData() {
     setError(null);
 
-    const [marketList, portfolioSummary] = await Promise.all([
+    const [marketList, portfolioSummary, orderHistory, activityHistory] = await Promise.all([
       fetchMarkets(),
-      fetchPortfolio(DEMO_WALLET_ID)
+      fetchPortfolio(DEMO_WALLET_ID),
+      fetchOrders(DEMO_WALLET_ID),
+      fetchActivity(DEMO_WALLET_ID)
     ]);
 
     setMarkets(marketList);
     setPortfolio(portfolioSummary);
+    setOrders(orderHistory);
+    setActivity(activityHistory);
   }
 
   useEffect(() => {
@@ -104,7 +120,8 @@ export function MarketDashboard() {
               </h1>
               <p className="mt-6 max-w-2xl text-lg leading-8 text-[var(--muted)]">
                 Markets and portfolio state are now loaded from the Go API. Every demo buy updates the
-                wallet and the open position model behind the scenes.
+                wallet, writes an order record, and emits an activity trail that stays visible in the
+                dashboard.
               </p>
             </div>
 
@@ -232,7 +249,7 @@ export function MarketDashboard() {
             </section>
           </div>
 
-          <div className="mt-6 grid gap-6 lg:grid-cols-2">
+          <div className="mt-6 grid gap-6 xl:grid-cols-2">
             <section className="rounded-[32px] border border-[var(--line)] bg-[var(--surface)] p-5 backdrop-blur">
               <p className="font-[var(--font-mono)] text-xs uppercase tracking-[0.28em] text-[var(--muted)]">
                 Balances
@@ -265,16 +282,73 @@ export function MarketDashboard() {
                     >
                       <div className="flex items-center justify-between gap-4">
                         <span className="text-lg font-semibold">{position.marketSymbol}</span>
-                        <span className="text-sm text-[var(--accent)]">{formatCurrency(position.positionValue)}</span>
+                        <span className="text-sm text-[var(--accent)]">
+                          {formatCurrency(position.positionValue)}
+                        </span>
                       </div>
                       <p className="mt-2 text-sm text-[var(--muted)]">
-                        Qty {formatNumber(position.entryQuantity)} at avg {formatCurrency(position.entryPriceAvg)}
+                        Qty {formatNumber(position.entryQuantity)} at avg{" "}
+                        {formatCurrency(position.entryPriceAvg)}
                       </p>
                     </div>
                   ))
                 ) : (
                   <div className="rounded-2xl border border-dashed border-[var(--line)] px-4 py-6 text-sm text-[var(--muted)]">
                     No open positions yet. Execute the first XRP or BTC demo buy to populate this view.
+                  </div>
+                )}
+              </div>
+            </section>
+
+            <section className="rounded-[32px] border border-[var(--line)] bg-[var(--surface)] p-5 backdrop-blur">
+              <p className="font-[var(--font-mono)] text-xs uppercase tracking-[0.28em] text-[var(--muted)]">
+                Recent orders
+              </p>
+              <div className="mt-5 grid gap-3">
+                {orders.length ? (
+                  orders.map((order) => (
+                    <div
+                      key={order.id}
+                      className="rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.45)] px-4 py-4"
+                    >
+                      <div className="flex items-center justify-between gap-4">
+                        <span className="text-lg font-semibold">{order.marketSymbol}</span>
+                        <span className="text-sm uppercase text-[var(--accent)]">{order.status}</span>
+                      </div>
+                      <p className="mt-2 text-sm text-[var(--muted)]">
+                        Quote {formatCurrency(order.quoteAmount)} at {formatCurrency(order.expectedPrice)}
+                      </p>
+                    </div>
+                  ))
+                ) : (
+                  <div className="rounded-2xl border border-dashed border-[var(--line)] px-4 py-6 text-sm text-[var(--muted)]">
+                    No orders yet. The next demo buy will appear here immediately.
+                  </div>
+                )}
+              </div>
+            </section>
+
+            <section className="rounded-[32px] border border-[var(--line)] bg-[var(--surface)] p-5 backdrop-blur">
+              <p className="font-[var(--font-mono)] text-xs uppercase tracking-[0.28em] text-[var(--muted)]">
+                Activity log
+              </p>
+              <div className="mt-5 grid gap-3">
+                {activity.length ? (
+                  activity.map((item) => (
+                    <div
+                      key={item.id}
+                      className="rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.45)] px-4 py-4"
+                    >
+                      <div className="flex items-center justify-between gap-4">
+                        <span className="text-lg font-semibold">{item.title}</span>
+                        <span className="text-sm uppercase text-[var(--accent-hot)]">{item.logType}</span>
+                      </div>
+                      <p className="mt-2 text-sm text-[var(--muted)]">{item.message}</p>
+                    </div>
+                  ))
+                ) : (
+                  <div className="rounded-2xl border border-dashed border-[var(--line)] px-4 py-6 text-sm text-[var(--muted)]">
+                    Activity will populate as soon as demo orders and bot actions start flowing.
                   </div>
                 )}
               </div>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -39,17 +39,29 @@ export type PortfolioSummary = {
   balances: Balance[];
 };
 
-const DEFAULT_API_BASE_URL = "http://localhost:8080";
+export type Order = {
+  id: string;
+  walletID: string;
+  marketSymbol: string;
+  quoteAmount: number;
+  expectedPrice: number;
+  status: string;
+  createdAt: string;
+};
 
-function getApiBaseUrl() {
-  return process.env.NEXT_PUBLIC_API_BASE_URL ?? DEFAULT_API_BASE_URL;
-}
+export type ActivityLog = {
+  id: string;
+  walletID: string;
+  logType: string;
+  title: string;
+  message: string;
+  createdAt: string;
+};
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080";
 
 export async function fetchMarkets(): Promise<Market[]> {
-  const response = await fetch(`${getApiBaseUrl()}/api/v1/markets`, {
-    cache: "no-store"
-  });
-
+  const response = await fetch(`${API_BASE_URL}/api/v1/markets`, { cache: "no-store" });
   if (!response.ok) {
     throw new Error("Failed to load markets");
   }
@@ -59,7 +71,7 @@ export async function fetchMarkets(): Promise<Market[]> {
 }
 
 export async function fetchPortfolio(walletID: string): Promise<PortfolioSummary> {
-  const response = await fetch(`${getApiBaseUrl()}/api/v1/portfolios/${walletID}`, {
+  const response = await fetch(`${API_BASE_URL}/api/v1/portfolios/${walletID}`, {
     cache: "no-store"
   });
 
@@ -71,6 +83,30 @@ export async function fetchPortfolio(walletID: string): Promise<PortfolioSummary
   return data.portfolio;
 }
 
+export async function fetchOrders(walletID: string): Promise<Order[]> {
+  const response = await fetch(`${API_BASE_URL}/api/v1/orders?wallet_id=${walletID}`, {
+    cache: "no-store"
+  });
+  if (!response.ok) {
+    throw new Error("Failed to load orders");
+  }
+
+  const data = await response.json();
+  return data.orders;
+}
+
+export async function fetchActivity(walletID: string): Promise<ActivityLog[]> {
+  const response = await fetch(`${API_BASE_URL}/api/v1/activity?wallet_id=${walletID}`, {
+    cache: "no-store"
+  });
+  if (!response.ok) {
+    throw new Error("Failed to load activity");
+  }
+
+  const data = await response.json();
+  return data.activity;
+}
+
 export async function placeMarketBuy(input: {
   userID: string;
   walletID: string;
@@ -78,7 +114,7 @@ export async function placeMarketBuy(input: {
   quoteAmount: number;
   expectedPrice: number;
 }) {
-  const response = await fetch(`${getApiBaseUrl()}/api/v1/orders`, {
+  const response = await fetch(`${API_BASE_URL}/api/v1/orders`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json"
@@ -93,8 +129,8 @@ export async function placeMarketBuy(input: {
   });
 
   if (!response.ok) {
-    const data = await response.json().catch(() => ({ error: "Order failed" }));
-    throw new Error(data.error ?? "Order failed");
+    const payload = await response.json().catch(() => ({ error: "Order failed" }));
+    throw new Error(payload.error ?? "Order failed");
   }
 
   return response.json();


### PR DESCRIPTION
## Summary
- add order and activity history endpoints for the demo wallet
- persist activity log entries whenever demo buy orders are created
- replace the static hero with an API-driven trade history dashboard

## Testing
- go test ./...
- npm run test
- npm run build