### PR TITLE
Add Kubernetes deployment automation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+.next
+backend/.cache
+backend/bin
+frontend/.next
+frontend/node_modules
+node_modules
+dist
+tmp
+coverage
+playwright-report
+test-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,44 @@ jobs:
       - name: Build frontend
         working-directory: frontend
         run: npm run build
+
+  backend-container:
+    name: Backend container build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Build backend image
+        run: docker build -f backend/Dockerfile -t tradelab-backend:test .
+
+  frontend-container:
+    name: Frontend container build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Build frontend image
+        run: docker build -f frontend/Dockerfile -t tradelab-frontend:test .
+
+  kubernetes-manifests:
+    name: Kubernetes manifests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: v1.32.2
+
+      - name: Render development overlay
+        run: kubectl kustomize deploy/kubernetes/overlays/development > /tmp/tradelab-dev.yaml
+
+      - name: Render production overlay
+        run: kubectl kustomize deploy/kubernetes/overlays/production > /tmp/tradelab-prod.yaml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,23 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
+  release-metadata:
+    name: Release metadata
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.meta.outputs.tag }}
+      name: ${{ steps.meta.outputs.name }}
+
+    steps:
+      - name: Generate release metadata
+        id: meta
+        run: |
+          echo "tag=v0.1.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+          echo "name=TradeLab Release v0.1.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+
   verify-backend:
     name: Verify backend
     runs-on: ubuntu-latest
@@ -56,6 +71,7 @@ jobs:
   build-backend:
     name: Build backend binaries
     needs:
+      - release-metadata
       - verify-backend
       - verify-frontend
     runs-on: ubuntu-latest
@@ -95,6 +111,7 @@ jobs:
   build-frontend:
     name: Build frontend artifact
     needs:
+      - release-metadata
       - verify-backend
       - verify-frontend
     runs-on: ubuntu-latest
@@ -132,11 +149,96 @@ jobs:
           name: tradelab-frontend-standalone
           path: dist/tradelab-frontend-standalone.tar.gz
 
+  publish-backend-image:
+    name: Publish backend image
+    needs:
+      - release-metadata
+      - verify-backend
+      - verify-frontend
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: backend/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/aidun/tradelab-backend:latest
+            ghcr.io/aidun/tradelab-backend:${{ needs.release-metadata.outputs.tag }}
+
+  publish-frontend-image:
+    name: Publish frontend image
+    needs:
+      - release-metadata
+      - verify-backend
+      - verify-frontend
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: frontend/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/aidun/tradelab-frontend:latest
+            ghcr.io/aidun/tradelab-frontend:${{ needs.release-metadata.outputs.tag }}
+
+  package-kubernetes-manifests:
+    name: Package Kubernetes manifests
+    needs:
+      - release-metadata
+      - publish-backend-image
+      - publish-frontend-image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Package Kubernetes manifests
+        run: |
+          mkdir -p dist
+          tar -czf dist/tradelab-kubernetes.tar.gz -C deploy kubernetes
+
+      - name: Upload manifest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tradelab-kubernetes
+          path: dist/tradelab-kubernetes.tar.gz
+
   create-release:
     name: Create GitHub release
     needs:
+      - release-metadata
       - build-backend
       - build-frontend
+      - publish-backend-image
+      - publish-frontend-image
+      - package-kubernetes-manifests
     runs-on: ubuntu-latest
 
     steps:
@@ -158,19 +260,20 @@ jobs:
           name: tradelab-frontend-standalone
           path: dist
 
-      - name: Generate release metadata
-        id: meta
-        run: |
-          echo "tag=v0.1.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
-          echo "name=TradeLab Release v0.1.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+      - name: Download Kubernetes artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: tradelab-kubernetes
+          path: dist
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.meta.outputs.tag }}
-          name: ${{ steps.meta.outputs.name }}
+          tag_name: ${{ needs.release-metadata.outputs.tag }}
+          name: ${{ needs.release-metadata.outputs.name }}
           generate_release_notes: true
           files: |
             dist/tradelab-api-linux-amd64
             dist/tradelab-api-windows-amd64.exe
             dist/tradelab-frontend-standalone.tar.gz
+            dist/tradelab-kubernetes.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ backend/.cache/
 .env
 .env.local
 tmp/
+.tools/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ TradeLab is a multi-asset crypto paper-trading platform with automated strategy 
 
 - `frontend/` web application
 - `backend/` API, domain logic, repositories, migrations
+- `deploy/` Kubernetes deployment manifests and overlays
 - `docs/` product and architecture documentation
 
 ## Local development
@@ -42,6 +43,13 @@ go run ./cmd/migrate up
 ```bash
 cd frontend
 npm run dev
+```
+
+### Build container images locally
+
+```bash
+docker build -f backend/Dockerfile -t tradelab-backend:local .
+docker build -f frontend/Dockerfile -t tradelab-frontend:local .
 ```
 
 ## Testing
@@ -102,8 +110,22 @@ cd frontend
 npm run test:e2e
 ```
 
+## Kubernetes deployment
+
+TradeLab ships with a complete Kubernetes deployment under `deploy/kubernetes`.
+
+Quick start for the development overlay:
+
+```bash
+kubectl apply -k deploy/kubernetes/overlays/development
+```
+
+This deploys PostgreSQL, the Go backend, the Next.js frontend, and an ingress that routes `/api` to the backend and `/` to the frontend.
+
+Full deployment notes live in [docs/deployment.md](docs/deployment.md).
+
 ## Delivery automation
 
 - Pull requests are validated by GitHub Actions.
 - Successful PR checks can be auto-merged into `master`.
-- Every successful `master` run builds release artifacts and creates a GitHub Release.
+- Every successful `master` run builds release artifacts, publishes container images to GitHub Container Registry, and creates a GitHub Release.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,27 @@
+FROM golang:1.26-alpine AS builder
+
+WORKDIR /src/backend
+
+COPY backend/go.mod backend/go.sum ./
+RUN go mod download
+
+COPY backend ./
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /out/tradelab-api ./cmd/api && \
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /out/tradelab-migrate ./cmd/migrate
+
+FROM alpine:3.22
+
+RUN addgroup -S tradelab && adduser -S tradelab -G tradelab
+
+WORKDIR /app
+
+COPY --from=builder /out/tradelab-api /app/tradelab-api
+COPY --from=builder /out/tradelab-migrate /app/tradelab-migrate
+COPY backend/migrations /app/migrations
+
+USER tradelab
+
+EXPOSE 8080
+
+ENTRYPOINT ["/app/tradelab-api"]

--- a/deploy/kubernetes/base/backend-configmap.yaml
+++ b/deploy/kubernetes/base/backend-configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tradelab-backend-config
+data:
+  HTTP_ADDRESS: ":8080"

--- a/deploy/kubernetes/base/backend-deployment.yaml
+++ b/deploy/kubernetes/base/backend-deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tradelab-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tradelab-backend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tradelab-backend
+    spec:
+      initContainers:
+        - name: migrate
+          image: ghcr.io/aidun/tradelab-backend:latest
+          imagePullPolicy: Always
+          command:
+            - /app/tradelab-migrate
+            - up
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: tradelab-database
+                  key: DATABASE_URL
+      containers:
+        - name: api
+          image: ghcr.io/aidun/tradelab-backend:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+              name: http
+          envFrom:
+            - configMapRef:
+                name: tradelab-backend-config
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: tradelab-database
+                  key: DATABASE_URL
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20

--- a/deploy/kubernetes/base/backend-service.yaml
+++ b/deploy/kubernetes/base/backend-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tradelab-backend
+spec:
+  selector:
+    app.kubernetes.io/name: tradelab-backend
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/deploy/kubernetes/base/database-secret.yaml
+++ b/deploy/kubernetes/base/database-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tradelab-database
+type: Opaque
+stringData:
+  POSTGRES_DB: tradelab
+  POSTGRES_USER: tradelab
+  POSTGRES_PASSWORD: tradelab-change-me
+  DATABASE_URL: postgres://tradelab:tradelab-change-me@tradelab-postgres:5432/tradelab?sslmode=disable

--- a/deploy/kubernetes/base/frontend-configmap.yaml
+++ b/deploy/kubernetes/base/frontend-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tradelab-frontend-config
+data:
+  PORT: "3000"
+  HOSTNAME: "0.0.0.0"
+  TRADESLAB_API_PROXY_TARGET: "http://tradelab-backend:8080"

--- a/deploy/kubernetes/base/frontend-deployment.yaml
+++ b/deploy/kubernetes/base/frontend-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tradelab-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tradelab-frontend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tradelab-frontend
+    spec:
+      containers:
+        - name: web
+          image: ghcr.io/aidun/tradelab-frontend:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3000
+              name: http
+          envFrom:
+            - configMapRef:
+                name: tradelab-frontend-config
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20

--- a/deploy/kubernetes/base/frontend-service.yaml
+++ b/deploy/kubernetes/base/frontend-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tradelab-frontend
+spec:
+  selector:
+    app.kubernetes.io/name: tradelab-frontend
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http

--- a/deploy/kubernetes/base/ingress.yaml
+++ b/deploy/kubernetes/base/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tradelab
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+    - host: tradelab.example.com
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: tradelab-backend
+                port:
+                  number: 8080
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: tradelab-frontend
+                port:
+                  number: 3000

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - backend-configmap.yaml
+  - frontend-configmap.yaml
+  - database-secret.yaml
+  - postgres-persistent-volume-claim.yaml
+  - postgres-service.yaml
+  - postgres-statefulset.yaml
+  - backend-service.yaml
+  - backend-deployment.yaml
+  - frontend-service.yaml
+  - frontend-deployment.yaml
+  - ingress.yaml
+
+images:
+  - name: ghcr.io/aidun/tradelab-backend
+    newTag: latest
+  - name: ghcr.io/aidun/tradelab-frontend
+    newTag: latest

--- a/deploy/kubernetes/base/postgres-persistent-volume-claim.yaml
+++ b/deploy/kubernetes/base/postgres-persistent-volume-claim.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: tradelab-postgres-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/deploy/kubernetes/base/postgres-service.yaml
+++ b/deploy/kubernetes/base/postgres-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tradelab-postgres
+spec:
+  selector:
+    app.kubernetes.io/name: tradelab-postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432

--- a/deploy/kubernetes/base/postgres-statefulset.yaml
+++ b/deploy/kubernetes/base/postgres-statefulset.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tradelab-postgres
+spec:
+  serviceName: tradelab-postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tradelab-postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tradelab-postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:17-alpine
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: tradelab-database
+                  key: POSTGRES_DB
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: tradelab-database
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: tradelab-database
+                  key: POSTGRES_PASSWORD
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: 15
+            periodSeconds: 20
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: tradelab-postgres-data

--- a/deploy/kubernetes/overlays/development/kustomization.yaml
+++ b/deploy/kubernetes/overlays/development/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: tradelab-dev
+
+resources:
+  - ../../base
+  - namespace.yaml
+
+patches:
+  - path: patch-ingress.yaml
+  - path: patch-database-secret.yaml

--- a/deploy/kubernetes/overlays/development/namespace.yaml
+++ b/deploy/kubernetes/overlays/development/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tradelab-dev

--- a/deploy/kubernetes/overlays/development/patch-database-secret.yaml
+++ b/deploy/kubernetes/overlays/development/patch-database-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tradelab-database
+stringData:
+  POSTGRES_PASSWORD: tradelab
+  DATABASE_URL: postgres://tradelab:tradelab@tradelab-postgres:5432/tradelab?sslmode=disable

--- a/deploy/kubernetes/overlays/development/patch-ingress.yaml
+++ b/deploy/kubernetes/overlays/development/patch-ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tradelab
+spec:
+  rules:
+    - host: tradelab.localtest.me
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: tradelab-backend
+                port:
+                  number: 8080
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: tradelab-frontend
+                port:
+                  number: 3000

--- a/deploy/kubernetes/overlays/production/kustomization.yaml
+++ b/deploy/kubernetes/overlays/production/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: tradelab
+
+resources:
+  - ../../base
+  - namespace.yaml
+
+patches:
+  - path: patch-backend-deployment.yaml
+  - path: patch-frontend-deployment.yaml
+  - path: patch-ingress.yaml
+  - path: patch-postgres-persistent-volume-claim.yaml

--- a/deploy/kubernetes/overlays/production/namespace.yaml
+++ b/deploy/kubernetes/overlays/production/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tradelab

--- a/deploy/kubernetes/overlays/production/patch-backend-deployment.yaml
+++ b/deploy/kubernetes/overlays/production/patch-backend-deployment.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tradelab-backend
+spec:
+  replicas: 2

--- a/deploy/kubernetes/overlays/production/patch-frontend-deployment.yaml
+++ b/deploy/kubernetes/overlays/production/patch-frontend-deployment.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tradelab-frontend
+spec:
+  replicas: 2

--- a/deploy/kubernetes/overlays/production/patch-ingress.yaml
+++ b/deploy/kubernetes/overlays/production/patch-ingress.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tradelab
+spec:
+  tls:
+    - hosts:
+        - tradelab.example.com
+      secretName: tradelab-tls
+  rules:
+    - host: tradelab.example.com
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: tradelab-backend
+                port:
+                  number: 8080
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: tradelab-frontend
+                port:
+                  number: 3000

--- a/deploy/kubernetes/overlays/production/patch-postgres-persistent-volume-claim.yaml
+++ b/deploy/kubernetes/overlays/production/patch-postgres-persistent-volume-claim.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: tradelab-postgres-data
+spec:
+  resources:
+    requests:
+      storage: 50Gi

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,70 @@
+# Kubernetes Deployment
+
+TradeLab ships with a Kubernetes deployment layout under `deploy/kubernetes` and publishes ready-to-run container images to GitHub Container Registry on every successful `master` release.
+
+## What gets deployed
+
+- `PostgreSQL` as a `StatefulSet` with a persistent volume claim
+- `TradeLab backend` as a `Deployment`
+- `TradeLab frontend` as a `Deployment`
+- `Ingress` routing `/` to the frontend and `/api` to the backend
+- automatic schema migration through a backend `initContainer`
+
+## Container images
+
+Every successful `master` release publishes:
+
+- `ghcr.io/aidun/tradelab-backend:latest`
+- `ghcr.io/aidun/tradelab-backend:v0.1.<run-number>`
+- `ghcr.io/aidun/tradelab-frontend:latest`
+- `ghcr.io/aidun/tradelab-frontend:v0.1.<run-number>`
+
+The Kubernetes manifests default to the `latest` tags so a fresh release can be deployed without patching image references first.
+
+## Layout
+
+- `deploy/kubernetes/base`: shared manifests
+- `deploy/kubernetes/overlays/development`: single-replica development environment
+- `deploy/kubernetes/overlays/production`: production defaults with two app replicas and larger database storage
+
+## Prerequisites
+
+- a Kubernetes cluster
+- an NGINX-compatible ingress controller
+- `kubectl` with `kustomize` support
+- access to the published `ghcr.io/aidun/*` images
+
+## Development deployment
+
+The development overlay uses:
+
+- namespace: `tradelab-dev`
+- host: `tradelab.localtest.me`
+- database password: `tradelab`
+
+Apply it with:
+
+```bash
+kubectl apply -k deploy/kubernetes/overlays/development
+```
+
+If you are testing locally with an ingress controller, map `tradelab.localtest.me` to your cluster ingress IP or use a wildcard resolver such as `localtest.me`.
+
+## Production deployment
+
+Before applying the production overlay, replace the placeholder database password and ingress host values:
+
+- `deploy/kubernetes/base/database-secret.yaml`
+- `deploy/kubernetes/overlays/production/patch-ingress.yaml`
+
+Then deploy:
+
+```bash
+kubectl apply -k deploy/kubernetes/overlays/production
+```
+
+## Operational notes
+
+- The backend waits on database connectivity implicitly through the migration init container.
+- Frontend requests can stay same-origin because the ingress sends `/api` traffic to the backend service.
+- The frontend also includes a rewrite fallback to `TRADESLAB_API_PROXY_TARGET`, which keeps local standalone runs aligned with the Kubernetes topology.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,29 @@
+FROM node:24-alpine AS builder
+
+WORKDIR /app
+
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+
+COPY frontend ./
+
+RUN npm run build
+
+FROM node:24-alpine
+
+RUN addgroup -S tradelab && adduser -S tradelab -G tradelab
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+
+USER tradelab
+
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -58,10 +58,18 @@ export type ActivityLog = {
   createdAt: string;
 };
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080";
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
+
+function apiUrl(path: string) {
+  if (API_BASE_URL === "") {
+    return path;
+  }
+
+  return `${API_BASE_URL}${path}`;
+}
 
 export async function fetchMarkets(): Promise<Market[]> {
-  const response = await fetch(`${API_BASE_URL}/api/v1/markets`, { cache: "no-store" });
+  const response = await fetch(apiUrl("/api/v1/markets"), { cache: "no-store" });
   if (!response.ok) {
     throw new Error("Failed to load markets");
   }
@@ -71,7 +79,7 @@ export async function fetchMarkets(): Promise<Market[]> {
 }
 
 export async function fetchPortfolio(walletID: string): Promise<PortfolioSummary> {
-  const response = await fetch(`${API_BASE_URL}/api/v1/portfolios/${walletID}`, {
+  const response = await fetch(apiUrl(`/api/v1/portfolios/${walletID}`), {
     cache: "no-store"
   });
 
@@ -84,7 +92,7 @@ export async function fetchPortfolio(walletID: string): Promise<PortfolioSummary
 }
 
 export async function fetchOrders(walletID: string): Promise<Order[]> {
-  const response = await fetch(`${API_BASE_URL}/api/v1/orders?wallet_id=${walletID}`, {
+  const response = await fetch(apiUrl(`/api/v1/orders?wallet_id=${walletID}`), {
     cache: "no-store"
   });
   if (!response.ok) {
@@ -96,7 +104,7 @@ export async function fetchOrders(walletID: string): Promise<Order[]> {
 }
 
 export async function fetchActivity(walletID: string): Promise<ActivityLog[]> {
-  const response = await fetch(`${API_BASE_URL}/api/v1/activity?wallet_id=${walletID}`, {
+  const response = await fetch(apiUrl(`/api/v1/activity?wallet_id=${walletID}`), {
     cache: "no-store"
   });
   if (!response.ok) {
@@ -114,7 +122,7 @@ export async function placeMarketBuy(input: {
   quoteAmount: number;
   expectedPrice: number;
 }) {
-  const response = await fetch(`${API_BASE_URL}/api/v1/orders`, {
+  const response = await fetch(apiUrl("/api/v1/orders"), {
     method: "POST",
     headers: {
       "Content-Type": "application/json"

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,17 @@
 import type { NextConfig } from "next";
 
+const apiProxyTarget = process.env.TRADESLAB_API_PROXY_TARGET ?? "http://localhost:8080";
+
 const nextConfig: NextConfig = {
-  output: "standalone"
+  output: "standalone",
+  async rewrites() {
+    return [
+      {
+        source: "/api/:path*",
+        destination: `${apiProxyTarget}/api/:path*`
+      }
+    ];
+  }
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- add Dockerfiles for the Go backend and Next.js frontend
- add Kubernetes base and environment overlays for PostgreSQL, backend, frontend, and ingress
- validate manifests in CI and publish container images plus Kubernetes artifacts in the release workflow

## Testing
- go test ./...
- npm run test
- npm run build
- kubectl kustomize deploy/kubernetes/overlays/development
- kubectl kustomize deploy/kubernetes/overlays/production

## Notes
- Docker is not installed on the local workstation, so container image builds were added to CI but not executed locally.