### PR TITLE
Add real market candles and chart view

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -26,13 +26,13 @@ func main() {
 	balanceRepository := postgres.NewBalanceRepository(db)
 	portfolioRepository := postgres.NewPortfolioRepository(db)
 
-	marketService := marketservice.NewService(marketRepository)
+	marketService := marketservice.NewService(marketRepository, cfg.MarketDataBaseURL)
 	orderService := orderservice.NewService(marketRepository, balanceRepository, portfolioRepository)
 	portfolioService := portfolioservice.NewService(portfolioRepository)
 	historyService := historyservice.NewService(portfolioRepository)
 	server := &http.Server{
 		Addr:    cfg.HTTPAddress,
-		Handler: httpapi.NewRouter(marketService, orderService, portfolioService, historyService, historyService),
+		Handler: httpapi.NewRouter(marketService, marketService, orderService, portfolioService, historyService, historyService),
 	}
 
 	log.Printf("TradeLab backend listening on %s", cfg.HTTPAddress)

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -3,14 +3,16 @@ package config
 import "os"
 
 type Config struct {
-	HTTPAddress string
-	DatabaseURL string
+	HTTPAddress       string
+	DatabaseURL       string
+	MarketDataBaseURL string
 }
 
 func Load() Config {
 	return Config{
-		HTTPAddress: getEnv("HTTP_ADDRESS", ":8080"),
-		DatabaseURL: getEnv("DATABASE_URL", "postgres://tradelab:tradelab@localhost:5432/tradelab?sslmode=disable"),
+		HTTPAddress:       getEnv("HTTP_ADDRESS", ":8080"),
+		DatabaseURL:       getEnv("DATABASE_URL", "postgres://tradelab:tradelab@localhost:5432/tradelab?sslmode=disable"),
+		MarketDataBaseURL: getEnv("MARKET_DATA_BASE_URL", "https://api.binance.com"),
 	}
 }
 

--- a/backend/internal/domain/market.go
+++ b/backend/internal/domain/market.go
@@ -1,5 +1,7 @@
 package domain
 
+import "time"
+
 type Market struct {
 	ID          string
 	Symbol      string
@@ -7,4 +9,16 @@ type Market struct {
 	QuoteAsset  string
 	MinNotional float64
 	Exchange    string
+}
+
+type Candle struct {
+	OpenTime    time.Time
+	CloseTime   time.Time
+	OpenPrice   float64
+	HighPrice   float64
+	LowPrice    float64
+	ClosePrice  float64
+	BaseVolume  float64
+	QuoteVolume float64
+	Trades      int64
 }

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -14,6 +15,10 @@ import (
 
 type MarketLister interface {
 	List(ctx context.Context) ([]domain.Market, error)
+}
+
+type MarketCandlesLister interface {
+	ListCandles(ctx context.Context, marketSymbol string, interval string, limit int) ([]domain.Candle, error)
 }
 
 type OrderPlacer interface {
@@ -32,7 +37,7 @@ type ActivityHistoryLister interface {
 	ListActivity(ctx context.Context, walletID string, limit int) ([]domain.ActivityLog, error)
 }
 
-func NewRouter(markets MarketLister, orders OrderPlacer, portfolios PortfolioGetter, orderHistory OrderHistoryLister, activityHistory ActivityHistoryLister) http.Handler {
+func NewRouter(markets MarketLister, marketCandles MarketCandlesLister, orders OrderPlacer, portfolios PortfolioGetter, orderHistory OrderHistoryLister, activityHistory ActivityHistoryLister) http.Handler {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
@@ -50,6 +55,38 @@ func NewRouter(markets MarketLister, orders OrderPlacer, portfolios PortfolioGet
 		}
 
 		writeJSON(w, http.StatusOK, map[string]any{"markets": items})
+	})
+
+	mux.HandleFunc("GET /api/v1/markets/", func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/candles") {
+			writeError(w, http.StatusNotFound, "route not found")
+			return
+		}
+
+		marketSymbol := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v1/markets/"), "/candles")
+		if marketSymbol == "" {
+			writeError(w, http.StatusBadRequest, "market symbol is required")
+			return
+		}
+
+		marketSymbol, err := url.PathUnescape(marketSymbol)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "market symbol is invalid")
+			return
+		}
+
+		candles, err := marketCandles.ListCandles(
+			r.Context(),
+			marketSymbol,
+			r.URL.Query().Get("interval"),
+			parseBoundedLimit(r.URL.Query().Get("limit"), 48, 1, 200),
+		)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to load candles")
+			return
+		}
+
+		writeJSON(w, http.StatusOK, map[string]any{"candles": candles})
 	})
 
 	mux.HandleFunc("GET /api/v1/portfolios/", func(w http.ResponseWriter, r *http.Request) {
@@ -142,12 +179,16 @@ func NewRouter(markets MarketLister, orders OrderPlacer, portfolios PortfolioGet
 }
 
 func parseLimit(raw string) int {
+	return parseBoundedLimit(raw, 10, 1, 100)
+}
+
+func parseBoundedLimit(raw string, fallback int, min int, max int) int {
 	if raw == "" {
-		return 10
+		return fallback
 	}
 	limit, err := strconv.Atoi(raw)
-	if err != nil || limit <= 0 || limit > 100 {
-		return 10
+	if err != nil || limit < min || limit > max {
+		return fallback
 	}
 	return limit
 }

--- a/backend/internal/http/router_test.go
+++ b/backend/internal/http/router_test.go
@@ -17,7 +17,7 @@ func TestHealthRoute(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	recorder := httptest.NewRecorder()
 
-	NewRouter(fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}).ServeHTTP(recorder, req)
+	NewRouter(fakeMarketLister{}, fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", recorder.Code)
@@ -32,7 +32,7 @@ func TestListMarketsRoute(t *testing.T) {
 		markets: []domain.Market{
 			{ID: "market-1", Symbol: "XRP/USDT", BaseAsset: "XRP", QuoteAsset: "USDT", Exchange: "demo"},
 		},
-	}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}).ServeHTTP(recorder, req)
+	}, fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", recorder.Code)
@@ -43,7 +43,7 @@ func TestPortfolioRoute(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/portfolios/wallet-1", nil)
 	recorder := httptest.NewRecorder()
 
-	NewRouter(fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{
+	NewRouter(fakeMarketLister{}, fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{
 		summary: domain.PortfolioSummary{WalletID: "wallet-1", BaseCurrency: "USDT", TotalValue: 10000},
 	}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}).ServeHTTP(recorder, req)
 
@@ -56,7 +56,7 @@ func TestListOrdersRoute(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/orders?wallet_id=wallet-1", nil)
 	recorder := httptest.NewRecorder()
 
-	NewRouter(fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{
+	NewRouter(fakeMarketLister{}, fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{
 		orders: []domain.Order{{ID: "order-1", WalletID: "wallet-1", MarketSymbol: "XRP/USDT"}},
 	}, fakeActivityHistoryLister{}).ServeHTTP(recorder, req)
 
@@ -73,7 +73,7 @@ func TestListActivityRoute(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/activity?wallet_id=wallet-1", nil)
 	recorder := httptest.NewRecorder()
 
-	NewRouter(fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{
+	NewRouter(fakeMarketLister{}, fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{
 		activity: []domain.ActivityLog{{ID: "log-1", WalletID: "wallet-1", Title: "Demo buy recorded", CreatedAt: time.Now()}},
 	}).ServeHTTP(recorder, req)
 
@@ -82,12 +82,32 @@ func TestListActivityRoute(t *testing.T) {
 	}
 }
 
+func TestListMarketCandlesRoute(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/markets/XRP%2FUSDT/candles?interval=1h&limit=2", nil)
+	recorder := httptest.NewRecorder()
+
+	NewRouter(fakeMarketLister{}, fakeMarketLister{
+		candles: []domain.Candle{
+			{OpenPrice: 0.62, HighPrice: 0.64, LowPrice: 0.61, ClosePrice: 0.63},
+			{OpenPrice: 0.63, HighPrice: 0.65, LowPrice: 0.62, ClosePrice: 0.64},
+		},
+	}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", recorder.Code)
+	}
+
+	if !strings.Contains(recorder.Body.String(), "\"candles\"") {
+		t.Fatalf("expected candles payload in response, got %s", recorder.Body.String())
+	}
+}
+
 func TestCreateOrderRoute(t *testing.T) {
 	body := bytes.NewBufferString(`{"user_id":"user-1","wallet_id":"wallet-1","market_symbol":"XRP/USDT","quote_amount":50,"expected_price":0.67}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orders", body)
 	recorder := httptest.NewRecorder()
 
-	NewRouter(fakeMarketLister{}, fakeOrderPlacer{
+	NewRouter(fakeMarketLister{}, fakeMarketLister{}, fakeOrderPlacer{
 		order: domain.Order{
 			ID:           "order-1",
 			UserID:       "user-1",
@@ -106,10 +126,14 @@ func TestCreateOrderRoute(t *testing.T) {
 
 type fakeMarketLister struct {
 	markets []domain.Market
+	candles []domain.Candle
 	err     error
 }
 
 func (f fakeMarketLister) List(context.Context) ([]domain.Market, error) { return f.markets, f.err }
+func (f fakeMarketLister) ListCandles(context.Context, string, string, int) ([]domain.Candle, error) {
+	return f.candles, f.err
+}
 
 type fakeOrderPlacer struct {
 	order domain.Order

--- a/backend/internal/service/market/service.go
+++ b/backend/internal/service/market/service.go
@@ -2,19 +2,176 @@ package market
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/aidun/tradelab/backend/internal/domain"
 	"github.com/aidun/tradelab/backend/internal/store"
 )
 
 type Service struct {
-	markets store.MarketRepository
+	markets           store.MarketRepository
+	marketDataBaseURL string
+	client            *http.Client
 }
 
-func NewService(markets store.MarketRepository) *Service {
-	return &Service{markets: markets}
+func NewService(markets store.MarketRepository, marketDataBaseURL string) *Service {
+	return &Service{
+		markets:           markets,
+		marketDataBaseURL: strings.TrimRight(marketDataBaseURL, "/"),
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
 }
 
 func (s *Service) List(ctx context.Context) ([]domain.Market, error) {
 	return s.markets.List(ctx)
+}
+
+func (s *Service) ListCandles(ctx context.Context, marketSymbol string, interval string, limit int) ([]domain.Candle, error) {
+	if interval == "" {
+		interval = "1h"
+	}
+
+	if limit <= 0 || limit > 200 {
+		limit = 48
+	}
+
+	market, err := s.markets.GetBySymbol(ctx, marketSymbol)
+	if err != nil {
+		return nil, fmt.Errorf("get market: %w", err)
+	}
+
+	query := url.Values{}
+	query.Set("symbol", strings.ReplaceAll(market.Symbol, "/", ""))
+	query.Set("interval", interval)
+	query.Set("limit", strconv.Itoa(limit))
+
+	endpoint := fmt.Sprintf("%s/api/v3/uiKlines?%s", s.marketDataBaseURL, query.Encode())
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create market data request: %w", err)
+	}
+
+	response, err := s.client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("request market data: %w", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("market data request failed with status %d", response.StatusCode)
+	}
+
+	var payload [][]any
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("decode market data: %w", err)
+	}
+
+	candles := make([]domain.Candle, 0, len(payload))
+	for _, row := range payload {
+		candle, err := parseCandle(row)
+		if err != nil {
+			return nil, err
+		}
+		candles = append(candles, candle)
+	}
+
+	return candles, nil
+}
+
+func parseCandle(row []any) (domain.Candle, error) {
+	if len(row) < 9 {
+		return domain.Candle{}, fmt.Errorf("unexpected candle payload length: %d", len(row))
+	}
+
+	openTime, err := parseUnixMilliseconds(row[0])
+	if err != nil {
+		return domain.Candle{}, fmt.Errorf("parse open time: %w", err)
+	}
+
+	closeTime, err := parseUnixMilliseconds(row[6])
+	if err != nil {
+		return domain.Candle{}, fmt.Errorf("parse close time: %w", err)
+	}
+
+	openPrice, err := parseStringFloat(row[1])
+	if err != nil {
+		return domain.Candle{}, fmt.Errorf("parse open price: %w", err)
+	}
+
+	highPrice, err := parseStringFloat(row[2])
+	if err != nil {
+		return domain.Candle{}, fmt.Errorf("parse high price: %w", err)
+	}
+
+	lowPrice, err := parseStringFloat(row[3])
+	if err != nil {
+		return domain.Candle{}, fmt.Errorf("parse low price: %w", err)
+	}
+
+	closePrice, err := parseStringFloat(row[4])
+	if err != nil {
+		return domain.Candle{}, fmt.Errorf("parse close price: %w", err)
+	}
+
+	baseVolume, err := parseStringFloat(row[5])
+	if err != nil {
+		return domain.Candle{}, fmt.Errorf("parse base volume: %w", err)
+	}
+
+	quoteVolume, err := parseStringFloat(row[7])
+	if err != nil {
+		return domain.Candle{}, fmt.Errorf("parse quote volume: %w", err)
+	}
+
+	trades, err := parseInt64(row[8])
+	if err != nil {
+		return domain.Candle{}, fmt.Errorf("parse trades: %w", err)
+	}
+
+	return domain.Candle{
+		OpenTime:    openTime,
+		CloseTime:   closeTime,
+		OpenPrice:   openPrice,
+		HighPrice:   highPrice,
+		LowPrice:    lowPrice,
+		ClosePrice:  closePrice,
+		BaseVolume:  baseVolume,
+		QuoteVolume: quoteVolume,
+		Trades:      trades,
+	}, nil
+}
+
+func parseUnixMilliseconds(value any) (time.Time, error) {
+	switch typed := value.(type) {
+	case float64:
+		return time.UnixMilli(int64(typed)).UTC(), nil
+	default:
+		return time.Time{}, fmt.Errorf("unsupported time type %T", value)
+	}
+}
+
+func parseStringFloat(value any) (float64, error) {
+	text, ok := value.(string)
+	if !ok {
+		return 0, fmt.Errorf("unsupported float type %T", value)
+	}
+
+	return strconv.ParseFloat(text, 64)
+}
+
+func parseInt64(value any) (int64, error) {
+	switch typed := value.(type) {
+	case float64:
+		return int64(typed), nil
+	default:
+		return 0, fmt.Errorf("unsupported integer type %T", value)
+	}
 }

--- a/backend/internal/service/market/service_test.go
+++ b/backend/internal/service/market/service_test.go
@@ -1,0 +1,74 @@
+package market
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aidun/tradelab/backend/internal/domain"
+)
+
+func TestListCandlesFetchesRemoteMarketData(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v3/uiKlines" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+
+		if got := r.URL.Query().Get("symbol"); got != "XRPUSDT" {
+			t.Fatalf("expected symbol XRPUSDT, got %s", got)
+		}
+
+		if got := r.URL.Query().Get("interval"); got != "1h" {
+			t.Fatalf("expected interval 1h, got %s", got)
+		}
+
+		if got := r.URL.Query().Get("limit"); got != "48" {
+			t.Fatalf("expected limit 48, got %s", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			[1743242400000, "0.6200", "0.6400", "0.6150", "0.6320", "1250000.0", 1743245999999, "789000.0", 8342, "0", "0", "0"],
+			[1743246000000, "0.6320", "0.6450", "0.6280", "0.6410", "1430000.0", 1743249599999, "912000.0", 9021, "0", "0", "0"]
+		]`))
+	}))
+	defer server.Close()
+
+	service := NewService(fakeMarketRepository{
+		market: domain.Market{
+			ID:         "market-1",
+			Symbol:     "XRP/USDT",
+			BaseAsset:  "XRP",
+			QuoteAsset: "USDT",
+		},
+	}, server.URL)
+	service.client = server.Client()
+
+	candles, err := service.ListCandles(context.Background(), "XRP/USDT", "1h", 48)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(candles) != 2 {
+		t.Fatalf("expected 2 candles, got %d", len(candles))
+	}
+
+	if candles[1].ClosePrice != 0.641 {
+		t.Fatalf("expected close price 0.641, got %f", candles[1].ClosePrice)
+	}
+}
+
+type fakeMarketRepository struct {
+	market  domain.Market
+	markets []domain.Market
+	err     error
+}
+
+func (f fakeMarketRepository) List(context.Context) ([]domain.Market, error) {
+	return f.markets, f.err
+}
+
+func (f fakeMarketRepository) GetBySymbol(context.Context, string) (domain.Market, error) {
+	return f.market, f.err
+}

--- a/frontend/__tests__/home.test.tsx
+++ b/frontend/__tests__/home.test.tsx
@@ -7,6 +7,39 @@ describe("Hero", () => {
     vi.spyOn(global, "fetch").mockImplementation((input) => {
       const url = String(input);
 
+      if (url.includes("/candles")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              candles: [
+                {
+                  openTime: "2026-03-29T10:00:00Z",
+                  closeTime: "2026-03-29T10:59:59Z",
+                  openPrice: 0.62,
+                  highPrice: 0.64,
+                  lowPrice: 0.61,
+                  closePrice: 0.63,
+                  baseVolume: 1200000,
+                  quoteVolume: 756000,
+                  trades: 8000
+                },
+                {
+                  openTime: "2026-03-29T11:00:00Z",
+                  closeTime: "2026-03-29T11:59:59Z",
+                  openPrice: 0.63,
+                  highPrice: 0.65,
+                  lowPrice: 0.62,
+                  closePrice: 0.64,
+                  baseVolume: 1400000,
+                  quoteVolume: 896000,
+                  trades: 9200
+                }
+              ]
+            })
+          )
+        );
+      }
+
       if (url.includes("/api/v1/markets")) {
         return Promise.resolve(
           new Response(
@@ -101,6 +134,7 @@ describe("Hero", () => {
       expect(screen.getAllByText(/xrp\/usdt/i)[0]).toBeInTheDocument();
     });
 
+    expect(screen.getByLabelText(/live market chart/i)).toBeInTheDocument();
     expect(screen.getByText(/run demo buy/i)).toBeInTheDocument();
     expect(screen.getByText(/demo buy recorded/i)).toBeInTheDocument();
   });

--- a/frontend/components/market-dashboard.tsx
+++ b/frontend/components/market-dashboard.tsx
@@ -3,11 +3,13 @@
 import React, { startTransition, useEffect, useState } from "react";
 import {
   fetchActivity,
+  fetchCandles,
   fetchMarkets,
   fetchOrders,
   fetchPortfolio,
   placeMarketBuy,
   type ActivityLog,
+  type Candle,
   type Market,
   type Order,
   type PortfolioSummary
@@ -30,33 +32,176 @@ function formatNumber(value: number) {
   }).format(value);
 }
 
+function formatShortTime(value: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric"
+  }).format(new Date(value));
+}
+
+function intervalLabel(interval: string) {
+  switch (interval) {
+    case "15m":
+      return "15m";
+    case "1h":
+      return "1h";
+    case "4h":
+      return "4h";
+    default:
+      return interval;
+  }
+}
+
+function getLastItem<T>(items: T[]) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return items[items.length - 1];
+}
+
+function CandleChart({ candles }: { candles: Candle[] }) {
+  if (candles.length === 0) {
+    return (
+      <div className="rounded-2xl border border-dashed border-[var(--line)] px-4 py-12 text-sm text-[var(--muted)]">
+        Candle data will appear as soon as the market feed responds.
+      </div>
+    );
+  }
+
+  const width = 960;
+  const height = 320;
+  const paddingX = 18;
+  const paddingY = 18;
+  const chartWidth = width - paddingX * 2;
+  const chartHeight = height - paddingY * 2;
+  const candleSlot = chartWidth / candles.length;
+  const candleWidth = Math.max(4, candleSlot * 0.56);
+
+  const low = Math.min(...candles.map((item) => item.lowPrice));
+  const high = Math.max(...candles.map((item) => item.highPrice));
+  const priceRange = Math.max(high - low, 0.0001);
+
+  function mapPrice(price: number) {
+    const normalized = (price - low) / priceRange;
+    return paddingY + chartHeight - normalized * chartHeight;
+  }
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      role="img"
+      aria-label="Live market chart"
+      className="h-[320px] w-full rounded-[28px] border border-[var(--line)] bg-[linear-gradient(180deg,rgba(8,24,38,0.96),rgba(4,11,22,0.96))] p-3"
+    >
+      <defs>
+        <linearGradient id="chartGlow" x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stopColor="rgba(110,242,211,0.24)" />
+          <stop offset="100%" stopColor="rgba(255,176,107,0.05)" />
+        </linearGradient>
+      </defs>
+
+      <rect x="0" y="0" width={width} height={height} fill="url(#chartGlow)" rx="24" />
+
+      {[0.2, 0.4, 0.6, 0.8].map((line) => (
+        <line
+          key={line}
+          x1={paddingX}
+          x2={width - paddingX}
+          y1={paddingY + chartHeight * line}
+          y2={paddingY + chartHeight * line}
+          stroke="rgba(187,199,212,0.12)"
+          strokeDasharray="4 8"
+        />
+      ))}
+
+      {candles.map((candle, index) => {
+        const x = paddingX + index * candleSlot + candleSlot / 2;
+        const wickTop = mapPrice(candle.highPrice);
+        const wickBottom = mapPrice(candle.lowPrice);
+        const openY = mapPrice(candle.openPrice);
+        const closeY = mapPrice(candle.closePrice);
+        const bodyTop = Math.min(openY, closeY);
+        const bodyHeight = Math.max(Math.abs(openY - closeY), 3);
+        const isBull = candle.closePrice >= candle.openPrice;
+
+        return (
+          <g key={`${candle.openTime}-${index}`}>
+            <line
+              x1={x}
+              x2={x}
+              y1={wickTop}
+              y2={wickBottom}
+              stroke={isBull ? "rgba(110,242,211,0.92)" : "rgba(255,107,120,0.92)"}
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+            <rect
+              x={x - candleWidth / 2}
+              y={bodyTop}
+              width={candleWidth}
+              height={bodyHeight}
+              rx="4"
+              fill={isBull ? "rgba(110,242,211,0.95)" : "rgba(255,107,120,0.95)"}
+            />
+          </g>
+        );
+      })}
+
+      {candles
+        .filter((_, index) => index % Math.max(1, Math.floor(candles.length / 5)) === 0)
+        .map((candle, index) => (
+          <text
+            key={`${candle.openTime}-${index}-label`}
+            x={paddingX + candles.findIndex((item) => item.openTime === candle.openTime) * candleSlot + candleSlot / 2}
+            y={height - 8}
+            textAnchor="middle"
+            fill="rgba(187,199,212,0.72)"
+            fontSize="12"
+          >
+            {formatShortTime(candle.openTime)}
+          </text>
+        ))}
+    </svg>
+  );
+}
+
 export function MarketDashboard() {
   const [markets, setMarkets] = useState<Market[]>([]);
   const [portfolio, setPortfolio] = useState<PortfolioSummary | null>(null);
   const [orders, setOrders] = useState<Order[]>([]);
   const [activity, setActivity] = useState<ActivityLog[]>([]);
+  const [candles, setCandles] = useState<Candle[]>([]);
   const [selectedMarket, setSelectedMarket] = useState("XRP/USDT");
+  const [selectedInterval, setSelectedInterval] = useState("1h");
   const [quoteAmount, setQuoteAmount] = useState("50");
   const [expectedPrice, setExpectedPrice] = useState("0.67");
   const [isLoading, setIsLoading] = useState(true);
+  const [isChartLoading, setIsChartLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
 
   async function loadData() {
     setError(null);
+    setIsChartLoading(true);
 
-    const [marketList, portfolioSummary, orderHistory, activityHistory] = await Promise.all([
+    const [marketList, portfolioSummary, orderHistory, activityHistory, marketCandles] = await Promise.all([
       fetchMarkets(),
       fetchPortfolio(DEMO_WALLET_ID),
       fetchOrders(DEMO_WALLET_ID),
-      fetchActivity(DEMO_WALLET_ID)
+      fetchActivity(DEMO_WALLET_ID),
+      fetchCandles(selectedMarket, selectedInterval, 48)
     ]);
 
     setMarkets(marketList);
     setPortfolio(portfolioSummary);
     setOrders(orderHistory);
     setActivity(activityHistory);
+    setCandles(marketCandles);
+    setExpectedPrice(getLastItem(marketCandles)?.closePrice.toFixed(4) ?? "0.67");
+    setIsChartLoading(false);
   }
 
   useEffect(() => {
@@ -67,6 +212,7 @@ export function MarketDashboard() {
         .catch((loadError: Error) => {
           if (!cancelled) {
             setError(loadError.message);
+            setIsChartLoading(false);
           }
         })
         .finally(() => {
@@ -79,7 +225,7 @@ export function MarketDashboard() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [selectedInterval, selectedMarket]);
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -105,6 +251,8 @@ export function MarketDashboard() {
     }
   }
 
+  const latestCandle = getLastItem(candles);
+
   return (
     <main className="grid-glow min-h-screen overflow-hidden px-6 py-8 md:px-10 lg:px-14">
       <section className="mx-auto flex w-full max-w-7xl flex-col gap-8">
@@ -119,9 +267,9 @@ export function MarketDashboard() {
                 <span className="block text-[var(--accent-warm)]">real wallet movement.</span>
               </h1>
               <p className="mt-6 max-w-2xl text-lg leading-8 text-[var(--muted)]">
-                Markets and portfolio state are now loaded from the Go API. Every demo buy updates the
-                wallet, writes an order record, and emits an activity trail that stays visible in the
-                dashboard.
+                Live market candles now stream into the dashboard from the backend. You can inspect the
+                active pair before sending a demo order and keep the chart, wallet, and trade log on one
+                screen.
               </p>
             </div>
 
@@ -137,8 +285,8 @@ export function MarketDashboard() {
                 </span>
               </div>
               <div className="flex items-center justify-between gap-8">
-                <span>Cash balance</span>
-                <span>{portfolio ? formatCurrency(portfolio.cashBalance) : "--"}</span>
+                <span>Last price</span>
+                <span>{latestCandle ? formatCurrency(latestCandle.closePrice) : "--"}</span>
               </div>
             </div>
           </div>
@@ -248,6 +396,74 @@ export function MarketDashboard() {
               </form>
             </section>
           </div>
+
+          <section className="mt-6 rounded-[32px] border border-[var(--line)] bg-[var(--surface)] p-5 backdrop-blur">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+              <div>
+                <p className="font-[var(--font-mono)] text-xs uppercase tracking-[0.28em] text-[var(--muted)]">
+                  Live market chart
+                </p>
+                <h2 className="mt-3 text-2xl font-semibold">{selectedMarket}</h2>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-3 text-sm text-[var(--muted)]">
+                <span className="rounded-full border border-[var(--line)] px-3 py-2">
+                  Last close {latestCandle ? formatCurrency(latestCandle.closePrice) : "--"}
+                </span>
+                {["15m", "1h", "4h"].map((interval) => (
+                  <button
+                    key={interval}
+                    type="button"
+                    onClick={() => setSelectedInterval(interval)}
+                    className={`rounded-full border px-3 py-2 transition ${
+                      selectedInterval === interval
+                        ? "border-[var(--accent)] bg-[rgba(110,242,211,0.1)] text-[var(--accent)]"
+                        : "border-[var(--line)]"
+                    }`}
+                  >
+                    {intervalLabel(interval)}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="mt-6">
+              {isChartLoading ? (
+                <div className="rounded-2xl border border-dashed border-[var(--line)] px-4 py-12 text-sm text-[var(--muted)]">
+                  Loading candle data...
+                </div>
+              ) : (
+                <CandleChart candles={candles} />
+              )}
+            </div>
+
+            <div className="mt-5 grid gap-3 md:grid-cols-3">
+              <div className="rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.45)] px-4 py-4">
+                <p className="font-[var(--font-mono)] text-xs uppercase tracking-[0.24em] text-[var(--muted)]">
+                  Session high
+                </p>
+                <p className="mt-3 text-2xl font-semibold">
+                  {latestCandle ? formatCurrency(latestCandle.highPrice) : "--"}
+                </p>
+              </div>
+              <div className="rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.45)] px-4 py-4">
+                <p className="font-[var(--font-mono)] text-xs uppercase tracking-[0.24em] text-[var(--muted)]">
+                  Session low
+                </p>
+                <p className="mt-3 text-2xl font-semibold">
+                  {latestCandle ? formatCurrency(latestCandle.lowPrice) : "--"}
+                </p>
+              </div>
+              <div className="rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.45)] px-4 py-4">
+                <p className="font-[var(--font-mono)] text-xs uppercase tracking-[0.24em] text-[var(--muted)]">
+                  Last volume
+                </p>
+                <p className="mt-3 text-2xl font-semibold">
+                  {latestCandle ? formatNumber(latestCandle.baseVolume) : "--"}
+                </p>
+              </div>
+            </div>
+          </section>
 
           <div className="mt-6 grid gap-6 xl:grid-cols-2">
             <section className="rounded-[32px] border border-[var(--line)] bg-[var(--surface)] p-5 backdrop-blur">

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -58,6 +58,18 @@ export type ActivityLog = {
   createdAt: string;
 };
 
+export type Candle = {
+  openTime: string;
+  closeTime: string;
+  openPrice: number;
+  highPrice: number;
+  lowPrice: number;
+  closePrice: number;
+  baseVolume: number;
+  quoteVolume: number;
+  trades: number;
+};
+
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
 
 function apiUrl(path: string) {
@@ -76,6 +88,19 @@ export async function fetchMarkets(): Promise<Market[]> {
 
   const data = await response.json();
   return data.markets;
+}
+
+export async function fetchCandles(marketSymbol: string, interval = "1h", limit = 48): Promise<Candle[]> {
+  const encodedSymbol = encodeURIComponent(marketSymbol);
+  const response = await fetch(apiUrl(`/api/v1/markets/${encodedSymbol}/candles?interval=${interval}&limit=${limit}`), {
+    cache: "no-store"
+  });
+  if (!response.ok) {
+    throw new Error("Failed to load candles");
+  }
+
+  const data = await response.json();
+  return data.candles;
 }
 
 export async function fetchPortfolio(walletID: string): Promise<PortfolioSummary> {


### PR DESCRIPTION
## Summary
- fetch real candle data from the official Binance uiKlines endpoint through the Go backend
- expose a candle API for markets and cover it with backend service/router tests
- add a live chart panel to the dashboard with interval switching and latest market stats

## Testing
- go test ./...
- npm run test
- npm run build

## Source
- Binance Spot API market data docs for uiKlines: https://developers.binance.info/docs/binance-spot-api-docs/rest-api/market-data-endpoints#uiklines