### PR TITLE
Add demo session authentication and wallet ownership

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -10,6 +10,7 @@ import (
 	marketservice "github.com/aidun/tradelab/backend/internal/service/market"
 	orderservice "github.com/aidun/tradelab/backend/internal/service/order"
 	portfolioservice "github.com/aidun/tradelab/backend/internal/service/portfolio"
+	sessionservice "github.com/aidun/tradelab/backend/internal/service/session"
 	"github.com/aidun/tradelab/backend/internal/store/postgres"
 )
 
@@ -25,14 +26,16 @@ func main() {
 	marketRepository := postgres.NewMarketRepository(db)
 	balanceRepository := postgres.NewBalanceRepository(db)
 	portfolioRepository := postgres.NewPortfolioRepository(db)
+	sessionRepository := postgres.NewDemoSessionRepository(db)
 
 	marketService := marketservice.NewService(marketRepository, cfg.MarketDataBaseURL)
 	orderService := orderservice.NewService(marketRepository, balanceRepository, portfolioRepository)
 	portfolioService := portfolioservice.NewService(portfolioRepository)
 	historyService := historyservice.NewService(portfolioRepository)
+	sessionService := sessionservice.NewService(sessionRepository)
 	server := &http.Server{
 		Addr:    cfg.HTTPAddress,
-		Handler: httpapi.NewRouter(marketService, marketService, orderService, portfolioService, historyService, historyService),
+		Handler: httpapi.NewRouter(marketService, marketService, orderService, portfolioService, historyService, historyService, sessionService),
 	}
 
 	log.Printf("TradeLab backend listening on %s", cfg.HTTPAddress)

--- a/backend/internal/domain/session.go
+++ b/backend/internal/domain/session.go
@@ -1,0 +1,13 @@
+package domain
+
+import "time"
+
+type DemoSession struct {
+	ID         string
+	UserID     string
+	WalletID   string
+	Token      string
+	ExpiresAt  time.Time
+	CreatedAt  time.Time
+	LastUsedAt time.Time
+}

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aidun/tradelab/backend/internal/domain"
 	orderservice "github.com/aidun/tradelab/backend/internal/service/order"
+	sessionservice "github.com/aidun/tradelab/backend/internal/service/session"
 )
 
 type MarketLister interface {
@@ -37,7 +38,12 @@ type ActivityHistoryLister interface {
 	ListActivity(ctx context.Context, walletID string, limit int) ([]domain.ActivityLog, error)
 }
 
-func NewRouter(markets MarketLister, marketCandles MarketCandlesLister, orders OrderPlacer, portfolios PortfolioGetter, orderHistory OrderHistoryLister, activityHistory ActivityHistoryLister) http.Handler {
+type DemoSessionManager interface {
+	CreateDemoSession(ctx context.Context) (domain.DemoSession, error)
+	Authenticate(ctx context.Context, token string) (domain.DemoSession, error)
+}
+
+func NewRouter(markets MarketLister, marketCandles MarketCandlesLister, orders OrderPlacer, portfolios PortfolioGetter, orderHistory OrderHistoryLister, activityHistory ActivityHistoryLister, sessions DemoSessionManager) http.Handler {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
@@ -89,10 +95,38 @@ func NewRouter(markets MarketLister, marketCandles MarketCandlesLister, orders O
 		writeJSON(w, http.StatusOK, map[string]any{"candles": candles})
 	})
 
+	mux.HandleFunc("POST /api/v1/sessions/demo", func(w http.ResponseWriter, r *http.Request) {
+		demoSession, err := sessions.CreateDemoSession(r.Context())
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to create demo session")
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, map[string]any{
+			"session": map[string]any{
+				"id":         demoSession.ID,
+				"user_id":    demoSession.UserID,
+				"wallet_id":  demoSession.WalletID,
+				"token":      demoSession.Token,
+				"expires_at": demoSession.ExpiresAt,
+			},
+		})
+	})
+
 	mux.HandleFunc("GET /api/v1/portfolios/", func(w http.ResponseWriter, r *http.Request) {
+		demoSession, ok := requireSession(w, r, sessions)
+		if !ok {
+			return
+		}
+
 		walletID := strings.TrimPrefix(r.URL.Path, "/api/v1/portfolios/")
 		if walletID == "" {
 			writeError(w, http.StatusBadRequest, "wallet ID is required")
+			return
+		}
+
+		if walletID != demoSession.WalletID {
+			writeError(w, http.StatusForbidden, "wallet access denied")
 			return
 		}
 
@@ -106,13 +140,12 @@ func NewRouter(markets MarketLister, marketCandles MarketCandlesLister, orders O
 	})
 
 	mux.HandleFunc("GET /api/v1/orders", func(w http.ResponseWriter, r *http.Request) {
-		walletID := r.URL.Query().Get("wallet_id")
-		if walletID == "" {
-			writeError(w, http.StatusBadRequest, "wallet_id is required")
+		demoSession, ok := requireSession(w, r, sessions)
+		if !ok {
 			return
 		}
 
-		items, err := orderHistory.ListOrders(r.Context(), walletID, parseLimit(r.URL.Query().Get("limit")))
+		items, err := orderHistory.ListOrders(r.Context(), demoSession.WalletID, parseLimit(r.URL.Query().Get("limit")))
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to load orders")
 			return
@@ -122,13 +155,12 @@ func NewRouter(markets MarketLister, marketCandles MarketCandlesLister, orders O
 	})
 
 	mux.HandleFunc("GET /api/v1/activity", func(w http.ResponseWriter, r *http.Request) {
-		walletID := r.URL.Query().Get("wallet_id")
-		if walletID == "" {
-			writeError(w, http.StatusBadRequest, "wallet_id is required")
+		demoSession, ok := requireSession(w, r, sessions)
+		if !ok {
 			return
 		}
 
-		items, err := activityHistory.ListActivity(r.Context(), walletID, parseLimit(r.URL.Query().Get("limit")))
+		items, err := activityHistory.ListActivity(r.Context(), demoSession.WalletID, parseLimit(r.URL.Query().Get("limit")))
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to load activity")
 			return
@@ -138,9 +170,12 @@ func NewRouter(markets MarketLister, marketCandles MarketCandlesLister, orders O
 	})
 
 	mux.HandleFunc("POST /api/v1/orders", func(w http.ResponseWriter, r *http.Request) {
+		demoSession, ok := requireSession(w, r, sessions)
+		if !ok {
+			return
+		}
+
 		var payload struct {
-			UserID        string  `json:"user_id"`
-			WalletID      string  `json:"wallet_id"`
 			MarketSymbol  string  `json:"market_symbol"`
 			QuoteAmount   float64 `json:"quote_amount"`
 			ExpectedPrice float64 `json:"expected_price"`
@@ -152,8 +187,8 @@ func NewRouter(markets MarketLister, marketCandles MarketCandlesLister, orders O
 		}
 
 		order, err := orders.PlaceMarketBuy(r.Context(), orderservice.PlaceMarketBuyInput{
-			UserID:        payload.UserID,
-			WalletID:      payload.WalletID,
+			UserID:        demoSession.UserID,
+			WalletID:      demoSession.WalletID,
 			MarketSymbol:  payload.MarketSymbol,
 			QuoteAmount:   payload.QuoteAmount,
 			ExpectedPrice: payload.ExpectedPrice,
@@ -176,6 +211,40 @@ func NewRouter(markets MarketLister, marketCandles MarketCandlesLister, orders O
 	})
 
 	return mux
+}
+
+func requireSession(w http.ResponseWriter, r *http.Request, sessions DemoSessionManager) (domain.DemoSession, bool) {
+	token, ok := bearerToken(r.Header.Get("Authorization"))
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "missing bearer token")
+		return domain.DemoSession{}, false
+	}
+
+	demoSession, err := sessions.Authenticate(r.Context(), token)
+	if err != nil {
+		statusCode := http.StatusUnauthorized
+		if !errors.Is(err, sessionservice.ErrInvalidSession) {
+			statusCode = http.StatusInternalServerError
+		}
+		writeError(w, statusCode, "invalid session token")
+		return domain.DemoSession{}, false
+	}
+
+	return demoSession, true
+}
+
+func bearerToken(header string) (string, bool) {
+	const prefix = "Bearer "
+	if !strings.HasPrefix(header, prefix) {
+		return "", false
+	}
+
+	token := strings.TrimSpace(strings.TrimPrefix(header, prefix))
+	if token == "" {
+		return "", false
+	}
+
+	return token, true
 }
 
 func parseLimit(raw string) int {

--- a/backend/internal/http/router_test.go
+++ b/backend/internal/http/router_test.go
@@ -17,10 +17,33 @@ func TestHealthRoute(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	recorder := httptest.NewRecorder()
 
-	NewRouter(fakeMarketLister{}, fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}).ServeHTTP(recorder, req)
+	NewRouter(fakeMarketLister{}, fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}, fakeSessionManager{}).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", recorder.Code)
+	}
+}
+
+func TestCreateDemoSessionRoute(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/demo", nil)
+	recorder := httptest.NewRecorder()
+
+	NewRouter(fakeMarketLister{}, fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}, fakeSessionManager{
+		session: domain.DemoSession{
+			ID:        "session-1",
+			UserID:    "user-1",
+			WalletID:  "wallet-1",
+			Token:     "token-1",
+			ExpiresAt: time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC),
+		},
+	}).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", recorder.Code)
+	}
+
+	if !strings.Contains(recorder.Body.String(), `"token":"token-1"`) {
+		t.Fatalf("expected token in response, got %s", recorder.Body.String())
 	}
 }
 
@@ -32,20 +55,48 @@ func TestListMarketsRoute(t *testing.T) {
 		markets: []domain.Market{
 			{ID: "market-1", Symbol: "XRP/USDT", BaseAsset: "XRP", QuoteAsset: "USDT", Exchange: "demo"},
 		},
-	}, fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}).ServeHTTP(recorder, req)
+	}, fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}, fakeSessionManager{}).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", recorder.Code)
 	}
 }
 
-func TestPortfolioRoute(t *testing.T) {
+func TestPortfolioRouteRequiresSession(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/portfolios/wallet-1", nil)
+	recorder := httptest.NewRecorder()
+
+	NewRouter(fakeMarketLister{}, fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}, fakeSessionManager{}).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", recorder.Code)
+	}
+}
+
+func TestPortfolioRouteRejectsForeignWallet(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/portfolios/wallet-2", nil)
+	req.Header.Set("Authorization", "Bearer token-1")
+	recorder := httptest.NewRecorder()
+
+	NewRouter(fakeMarketLister{}, fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}, fakeSessionManager{
+		session: domain.DemoSession{UserID: "user-1", WalletID: "wallet-1"},
+	}).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", recorder.Code)
+	}
+}
+
+func TestPortfolioRouteReturnsOwnedWallet(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/portfolios/wallet-1", nil)
+	req.Header.Set("Authorization", "Bearer token-1")
 	recorder := httptest.NewRecorder()
 
 	NewRouter(fakeMarketLister{}, fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{
 		summary: domain.PortfolioSummary{WalletID: "wallet-1", BaseCurrency: "USDT", TotalValue: 10000},
-	}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}).ServeHTTP(recorder, req)
+	}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}, fakeSessionManager{
+		session: domain.DemoSession{UserID: "user-1", WalletID: "wallet-1"},
+	}).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", recorder.Code)
@@ -53,12 +104,15 @@ func TestPortfolioRoute(t *testing.T) {
 }
 
 func TestListOrdersRoute(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/orders?wallet_id=wallet-1", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/orders", nil)
+	req.Header.Set("Authorization", "Bearer token-1")
 	recorder := httptest.NewRecorder()
 
 	NewRouter(fakeMarketLister{}, fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{
 		orders: []domain.Order{{ID: "order-1", WalletID: "wallet-1", MarketSymbol: "XRP/USDT"}},
-	}, fakeActivityHistoryLister{}).ServeHTTP(recorder, req)
+	}, fakeActivityHistoryLister{}, fakeSessionManager{
+		session: domain.DemoSession{UserID: "user-1", WalletID: "wallet-1"},
+	}).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", recorder.Code)
@@ -70,11 +124,14 @@ func TestListOrdersRoute(t *testing.T) {
 }
 
 func TestListActivityRoute(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/activity?wallet_id=wallet-1", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/activity", nil)
+	req.Header.Set("Authorization", "Bearer token-1")
 	recorder := httptest.NewRecorder()
 
 	NewRouter(fakeMarketLister{}, fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{
 		activity: []domain.ActivityLog{{ID: "log-1", WalletID: "wallet-1", Title: "Demo buy recorded", CreatedAt: time.Now()}},
+	}, fakeSessionManager{
+		session: domain.DemoSession{UserID: "user-1", WalletID: "wallet-1"},
 	}).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -91,7 +148,7 @@ func TestListMarketCandlesRoute(t *testing.T) {
 			{OpenPrice: 0.62, HighPrice: 0.64, LowPrice: 0.61, ClosePrice: 0.63},
 			{OpenPrice: 0.63, HighPrice: 0.65, LowPrice: 0.62, ClosePrice: 0.64},
 		},
-	}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}).ServeHTTP(recorder, req)
+	}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}, fakeSessionManager{}).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", recorder.Code)
@@ -103,8 +160,9 @@ func TestListMarketCandlesRoute(t *testing.T) {
 }
 
 func TestCreateOrderRoute(t *testing.T) {
-	body := bytes.NewBufferString(`{"user_id":"user-1","wallet_id":"wallet-1","market_symbol":"XRP/USDT","quote_amount":50,"expected_price":0.67}`)
+	body := bytes.NewBufferString(`{"market_symbol":"XRP/USDT","quote_amount":50,"expected_price":0.67}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orders", body)
+	req.Header.Set("Authorization", "Bearer token-1")
 	recorder := httptest.NewRecorder()
 
 	NewRouter(fakeMarketLister{}, fakeMarketLister{}, fakeOrderPlacer{
@@ -117,7 +175,9 @@ func TestCreateOrderRoute(t *testing.T) {
 			QuoteAmount:  50,
 			Status:       domain.OrderStatusFilled,
 		},
-	}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}).ServeHTTP(recorder, req)
+	}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}, fakeSessionManager{
+		session: domain.DemoSession{UserID: "user-1", WalletID: "wallet-1"},
+	}).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d", recorder.Code)
@@ -169,4 +229,17 @@ type fakeActivityHistoryLister struct {
 
 func (f fakeActivityHistoryLister) ListActivity(context.Context, string, int) ([]domain.ActivityLog, error) {
 	return f.activity, f.err
+}
+
+type fakeSessionManager struct {
+	session domain.DemoSession
+	err     error
+}
+
+func (f fakeSessionManager) CreateDemoSession(context.Context) (domain.DemoSession, error) {
+	return f.session, f.err
+}
+
+func (f fakeSessionManager) Authenticate(context.Context, string) (domain.DemoSession, error) {
+	return f.session, f.err
 }

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -1,0 +1,55 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/aidun/tradelab/backend/internal/domain"
+	"github.com/aidun/tradelab/backend/internal/store"
+)
+
+var ErrInvalidSession = errors.New("invalid session token")
+
+type Clock interface {
+	Now() time.Time
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time {
+	return time.Now().UTC()
+}
+
+type Service struct {
+	sessions store.DemoSessionRepository
+	clock    Clock
+}
+
+func NewService(sessions store.DemoSessionRepository) *Service {
+	return &Service{
+		sessions: sessions,
+		clock:    realClock{},
+	}
+}
+
+func (s *Service) CreateDemoSession(ctx context.Context) (domain.DemoSession, error) {
+	return s.sessions.CreateDemoSession(ctx)
+}
+
+func (s *Service) Authenticate(ctx context.Context, token string) (domain.DemoSession, error) {
+	if token == "" {
+		return domain.DemoSession{}, ErrInvalidSession
+	}
+
+	session, err := s.sessions.GetByToken(ctx, token)
+	if err != nil {
+		return domain.DemoSession{}, ErrInvalidSession
+	}
+
+	if !session.ExpiresAt.After(s.clock.Now()) {
+		return domain.DemoSession{}, ErrInvalidSession
+	}
+
+	return session, nil
+}

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -1,0 +1,95 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aidun/tradelab/backend/internal/domain"
+)
+
+func TestAuthenticateReturnsErrorForMissingToken(t *testing.T) {
+	service := NewService(fakeSessionRepository{})
+
+	_, err := service.Authenticate(context.Background(), "")
+	if !errors.Is(err, ErrInvalidSession) {
+		t.Fatalf("expected ErrInvalidSession, got %v", err)
+	}
+}
+
+func TestAuthenticateReturnsErrorForExpiredSession(t *testing.T) {
+	service := NewService(fakeSessionRepository{
+		session: domain.DemoSession{
+			ID:        "session-1",
+			UserID:    "user-1",
+			WalletID:  "wallet-1",
+			ExpiresAt: time.Date(2026, 3, 29, 10, 0, 0, 0, time.UTC),
+		},
+	})
+	service.clock = fakeClock{now: time.Date(2026, 3, 29, 12, 0, 0, 0, time.UTC)}
+
+	_, err := service.Authenticate(context.Background(), "token")
+	if !errors.Is(err, ErrInvalidSession) {
+		t.Fatalf("expected ErrInvalidSession, got %v", err)
+	}
+}
+
+func TestAuthenticateReturnsSessionForValidToken(t *testing.T) {
+	expiresAt := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	service := NewService(fakeSessionRepository{
+		session: domain.DemoSession{
+			ID:        "session-1",
+			UserID:    "user-1",
+			WalletID:  "wallet-1",
+			ExpiresAt: expiresAt,
+		},
+	})
+	service.clock = fakeClock{now: time.Date(2026, 3, 29, 12, 0, 0, 0, time.UTC)}
+
+	session, err := service.Authenticate(context.Background(), "token")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if session.WalletID != "wallet-1" {
+		t.Fatalf("expected wallet-1, got %s", session.WalletID)
+	}
+}
+
+func TestCreateDemoSessionReturnsSession(t *testing.T) {
+	service := NewService(fakeSessionRepository{
+		session: domain.DemoSession{
+			ID:       "session-1",
+			UserID:   "user-1",
+			WalletID: "wallet-1",
+			Token:    "token",
+		},
+	})
+
+	session, err := service.CreateDemoSession(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if session.Token != "token" {
+		t.Fatalf("expected token to be returned")
+	}
+}
+
+type fakeSessionRepository struct {
+	session domain.DemoSession
+	err     error
+}
+
+func (f fakeSessionRepository) CreateDemoSession(context.Context) (domain.DemoSession, error) {
+	return f.session, f.err
+}
+
+func (f fakeSessionRepository) GetByToken(context.Context, string) (domain.DemoSession, error) {
+	return f.session, f.err
+}
+
+type fakeClock struct{ now time.Time }
+
+func (f fakeClock) Now() time.Time { return f.now }

--- a/backend/internal/store/postgres/postgres.go
+++ b/backend/internal/store/postgres/postgres.go
@@ -2,10 +2,16 @@ package postgres
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/base64"
+	"encoding/hex"
 	"fmt"
+	"time"
 
 	"github.com/aidun/tradelab/backend/internal/domain"
+	"github.com/google/uuid"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
 )
@@ -89,6 +95,100 @@ func (r *BalanceRepository) GetByWalletAndAsset(ctx context.Context, walletID st
 	return balance, nil
 }
 
+type DemoSessionRepository struct {
+	db *sql.DB
+}
+
+func NewDemoSessionRepository(db *sql.DB) *DemoSessionRepository {
+	return &DemoSessionRepository{db: db}
+}
+
+func (r *DemoSessionRepository) CreateDemoSession(ctx context.Context) (domain.DemoSession, error) {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return domain.DemoSession{}, err
+	}
+	defer tx.Rollback()
+
+	now := time.Now().UTC()
+	expiresAt := now.Add(30 * 24 * time.Hour)
+	userID := newUUID()
+	walletID := newUUID()
+	sessionID := newUUID()
+	token, tokenHash, err := newSessionToken()
+	if err != nil {
+		return domain.DemoSession{}, err
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO users (id, email, password_hash, display_name, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $5)
+	`, userID, "demo+"+userID+"@tradelab.local", "demo-session", "Demo "+userID[:8], now); err != nil {
+		return domain.DemoSession{}, err
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO wallets (id, user_id, wallet_type, base_currency, starting_balance, created_at, updated_at)
+		VALUES ($1, $2, 'paper', 'USDT', 10000, $3, $3)
+	`, walletID, userID, now); err != nil {
+		return domain.DemoSession{}, err
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO wallet_balances (id, wallet_id, asset_id, available_amount, locked_amount, average_entry_price, updated_at)
+		SELECT $1, $2, id, 10000, 0, 1, $3
+		FROM assets
+		WHERE symbol = 'USDT'
+	`, newUUID(), walletID, now); err != nil {
+		return domain.DemoSession{}, err
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO demo_sessions (id, user_id, wallet_id, token_hash, expires_at, created_at, last_used_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $6)
+	`, sessionID, userID, walletID, tokenHash, expiresAt, now); err != nil {
+		return domain.DemoSession{}, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return domain.DemoSession{}, err
+	}
+
+	return domain.DemoSession{
+		ID:         sessionID,
+		UserID:     userID,
+		WalletID:   walletID,
+		Token:      token,
+		ExpiresAt:  expiresAt,
+		CreatedAt:  now,
+		LastUsedAt: now,
+	}, nil
+}
+
+func (r *DemoSessionRepository) GetByToken(ctx context.Context, token string) (domain.DemoSession, error) {
+	var session domain.DemoSession
+	tokenHash := hashToken(token)
+
+	err := r.db.QueryRowContext(ctx, `
+		UPDATE demo_sessions
+		SET last_used_at = NOW()
+		WHERE token_hash = $1
+		RETURNING id, user_id, wallet_id, expires_at, created_at, last_used_at
+	`, tokenHash).Scan(
+		&session.ID,
+		&session.UserID,
+		&session.WalletID,
+		&session.ExpiresAt,
+		&session.CreatedAt,
+		&session.LastUsedAt,
+	)
+	if err != nil {
+		return domain.DemoSession{}, err
+	}
+
+	return session, nil
+}
+
 type PortfolioRepository struct {
 	db *sql.DB
 }
@@ -116,13 +216,19 @@ func (r *PortfolioRepository) ApplyMarketBuy(ctx context.Context, order domain.O
 	}
 
 	if _, err := tx.ExecContext(ctx, `
-		UPDATE wallet_balances wb
-		SET available_amount = wb.available_amount + $1, average_entry_price = $2, updated_at = NOW()
+		INSERT INTO wallet_balances (id, wallet_id, asset_id, available_amount, locked_amount, average_entry_price, updated_at)
+		SELECT $1, $2, a.id, $3, 0, $4, NOW()
 		FROM assets a
-		WHERE wb.wallet_id = $3
-		  AND wb.asset_id = a.id
-		  AND a.symbol = $4
-	`, order.BaseQuantity, order.ExpectedPrice, order.WalletID, order.BaseAsset); err != nil {
+		WHERE a.symbol = $5
+		ON CONFLICT (wallet_id, asset_id)
+		DO UPDATE SET
+			available_amount = wallet_balances.available_amount + EXCLUDED.available_amount,
+			average_entry_price = (
+				((wallet_balances.available_amount * wallet_balances.average_entry_price) + (EXCLUDED.available_amount * EXCLUDED.average_entry_price))
+				/ NULLIF(wallet_balances.available_amount + EXCLUDED.available_amount, 0)
+			),
+			updated_at = NOW()
+	`, newUUID(), order.WalletID, order.BaseQuantity, order.ExpectedPrice, order.BaseAsset); err != nil {
 		return domain.Order{}, err
 	}
 
@@ -357,4 +463,23 @@ func (r *PortfolioRepository) ListActivityByWallet(ctx context.Context, walletID
 
 func (r *PortfolioRepository) Create(ctx context.Context, order domain.Order) (domain.Order, error) {
 	return domain.Order{}, fmt.Errorf("unsupported operation: use ApplyMarketBuy")
+}
+
+func newUUID() string {
+	return uuid.NewString()
+}
+
+func newSessionToken() (string, string, error) {
+	entropy := make([]byte, 32)
+	if _, err := rand.Read(entropy); err != nil {
+		return "", "", err
+	}
+
+	token := base64.RawURLEncoding.EncodeToString(entropy)
+	return token, hashToken(token), nil
+}
+
+func hashToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
 }

--- a/backend/internal/store/store.go
+++ b/backend/internal/store/store.go
@@ -15,6 +15,11 @@ type BalanceRepository interface {
 	GetByWalletAndAsset(ctx context.Context, walletID string, assetSymbol string) (domain.Balance, error)
 }
 
+type DemoSessionRepository interface {
+	CreateDemoSession(ctx context.Context) (domain.DemoSession, error)
+	GetByToken(ctx context.Context, token string) (domain.DemoSession, error)
+}
+
 type OrderRepository interface {
 	Create(ctx context.Context, order domain.Order) (domain.Order, error)
 	ListByWallet(ctx context.Context, walletID string, limit int) ([]domain.Order, error)

--- a/backend/migrations/000006_add_demo_sessions.down.sql
+++ b/backend/migrations/000006_add_demo_sessions.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_demo_sessions_token_hash;
+DROP TABLE IF EXISTS demo_sessions;

--- a/backend/migrations/000006_add_demo_sessions.up.sql
+++ b/backend/migrations/000006_add_demo_sessions.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE demo_sessions (
+  id UUID PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES users(id),
+  wallet_id UUID NOT NULL REFERENCES wallets(id),
+  token_hash TEXT NOT NULL UNIQUE,
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_used_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_demo_sessions_token_hash ON demo_sessions (token_hash);

--- a/frontend/__tests__/home.test.tsx
+++ b/frontend/__tests__/home.test.tsx
@@ -7,6 +7,22 @@ describe("Hero", () => {
     vi.spyOn(global, "fetch").mockImplementation((input) => {
       const url = String(input);
 
+      if (url.includes("/api/v1/sessions/demo")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              session: {
+                id: "session-1",
+                user_id: "user-1",
+                wallet_id: "wallet-1",
+                token: "token-1",
+                expires_at: "2026-04-29T12:00:00Z"
+              }
+            })
+          )
+        );
+      }
+
       if (url.includes("/candles")) {
         return Promise.resolve(
           new Response(

--- a/frontend/components/market-dashboard.tsx
+++ b/frontend/components/market-dashboard.tsx
@@ -2,6 +2,7 @@
 
 import React, { startTransition, useEffect, useState } from "react";
 import {
+  createDemoSession,
   fetchActivity,
   fetchCandles,
   fetchMarkets,
@@ -10,13 +11,13 @@ import {
   placeMarketBuy,
   type ActivityLog,
   type Candle,
+  type DemoSession,
   type Market,
   type Order,
   type PortfolioSummary
 } from "@/lib/api";
 
-const DEMO_USER_ID = "cfbf7c8f-eaf9-47fa-8674-2a29fed1fcc9";
-const DEMO_WALLET_ID = "1ddb1c1c-827f-4bf0-b85a-3d5786c3b26c";
+const DEMO_SESSION_STORAGE_KEY = "tradelab.demo-session";
 
 function formatCurrency(value: number) {
   return new Intl.NumberFormat("en-US", {
@@ -168,6 +169,7 @@ function CandleChart({ candles }: { candles: Candle[] }) {
 }
 
 export function MarketDashboard() {
+  const [session, setSession] = useState<DemoSession | null>(null);
   const [markets, setMarkets] = useState<Market[]>([]);
   const [portfolio, setPortfolio] = useState<PortfolioSummary | null>(null);
   const [orders, setOrders] = useState<Order[]>([]);
@@ -183,15 +185,37 @@ export function MarketDashboard() {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
 
-  async function loadData() {
+  async function ensureDemoSession() {
+    if (typeof window === "undefined") {
+      throw new Error("Demo session can only be created in the browser");
+    }
+
+    const cachedValue = window.localStorage.getItem(DEMO_SESSION_STORAGE_KEY);
+    if (cachedValue) {
+      try {
+        const cachedSession = JSON.parse(cachedValue) as DemoSession;
+        if (new Date(cachedSession.expiresAt).getTime() > Date.now()) {
+          return cachedSession;
+        }
+      } catch {
+        window.localStorage.removeItem(DEMO_SESSION_STORAGE_KEY);
+      }
+    }
+
+    const nextSession = await createDemoSession();
+    window.localStorage.setItem(DEMO_SESSION_STORAGE_KEY, JSON.stringify(nextSession));
+    return nextSession;
+  }
+
+  async function loadData(activeSession: DemoSession) {
     setError(null);
     setIsChartLoading(true);
 
     const [marketList, portfolioSummary, orderHistory, activityHistory, marketCandles] = await Promise.all([
       fetchMarkets(),
-      fetchPortfolio(DEMO_WALLET_ID),
-      fetchOrders(DEMO_WALLET_ID),
-      fetchActivity(DEMO_WALLET_ID),
+      fetchPortfolio(activeSession.walletID, activeSession.token),
+      fetchOrders(activeSession.token),
+      fetchActivity(activeSession.token),
       fetchCandles(selectedMarket, selectedInterval, 48)
     ]);
 
@@ -208,7 +232,15 @@ export function MarketDashboard() {
     let cancelled = false;
 
     startTransition(() => {
-      loadData()
+      ensureDemoSession()
+        .then((activeSession) => {
+          if (cancelled) {
+            return;
+          }
+
+          setSession(activeSession);
+          return loadData(activeSession);
+        })
         .catch((loadError: Error) => {
           if (!cancelled) {
             setError(loadError.message);
@@ -234,15 +266,18 @@ export function MarketDashboard() {
     setIsSubmitting(true);
 
     try {
+      if (!session) {
+        throw new Error("Demo session is not ready yet");
+      }
+
       await placeMarketBuy({
-        userID: DEMO_USER_ID,
-        walletID: DEMO_WALLET_ID,
+        token: session.token,
         marketSymbol: selectedMarket,
         quoteAmount: Number(quoteAmount),
         expectedPrice: Number(expectedPrice)
       });
 
-      await loadData();
+      await loadData(session);
       setSuccess(`Demo buy executed for ${selectedMarket}.`);
     } catch (submitError) {
       setError(submitError instanceof Error ? submitError.message : "Order failed");
@@ -276,7 +311,7 @@ export function MarketDashboard() {
             <div className="grid min-w-[300px] gap-4 rounded-[28px] border border-[var(--line)] bg-[rgba(7,17,31,0.78)] p-5 font-[var(--font-mono)] text-sm text-[var(--muted)]">
               <div className="flex items-center justify-between gap-8">
                 <span>Demo wallet</span>
-                <span>{DEMO_WALLET_ID.slice(0, 8)}...</span>
+                <span>{session ? `${session.walletID.slice(0, 8)}...` : "--"}</span>
               </div>
               <div className="flex items-center justify-between gap-8">
                 <span>Total value</span>
@@ -388,7 +423,7 @@ export function MarketDashboard() {
 
                 <button
                   type="submit"
-                  disabled={isSubmitting || isLoading}
+                  disabled={isSubmitting || isLoading || !session}
                   className="mt-2 rounded-2xl bg-[var(--accent)] px-5 py-4 font-semibold text-[#04111a] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   {isSubmitting ? "Executing..." : "Run demo buy"}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -58,6 +58,14 @@ export type ActivityLog = {
   createdAt: string;
 };
 
+export type DemoSession = {
+  id: string;
+  userID: string;
+  walletID: string;
+  token: string;
+  expiresAt: string;
+};
+
 export type Candle = {
   openTime: string;
   closeTime: string;
@@ -78,6 +86,38 @@ function apiUrl(path: string) {
   }
 
   return `${API_BASE_URL}${path}`;
+}
+
+function authHeaders(token?: string) {
+  if (!token) {
+    return undefined;
+  }
+
+  return {
+    Authorization: `Bearer ${token}`
+  };
+}
+
+export async function createDemoSession(): Promise<DemoSession> {
+  const response = await fetch(apiUrl("/api/v1/sessions/demo"), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to create demo session");
+  }
+
+  const data = await response.json();
+  return {
+    id: data.session.id,
+    userID: data.session.user_id,
+    walletID: data.session.wallet_id,
+    token: data.session.token,
+    expiresAt: data.session.expires_at
+  };
 }
 
 export async function fetchMarkets(): Promise<Market[]> {
@@ -103,9 +143,10 @@ export async function fetchCandles(marketSymbol: string, interval = "1h", limit 
   return data.candles;
 }
 
-export async function fetchPortfolio(walletID: string): Promise<PortfolioSummary> {
+export async function fetchPortfolio(walletID: string, token: string): Promise<PortfolioSummary> {
   const response = await fetch(apiUrl(`/api/v1/portfolios/${walletID}`), {
-    cache: "no-store"
+    cache: "no-store",
+    headers: authHeaders(token)
   });
 
   if (!response.ok) {
@@ -116,9 +157,10 @@ export async function fetchPortfolio(walletID: string): Promise<PortfolioSummary
   return data.portfolio;
 }
 
-export async function fetchOrders(walletID: string): Promise<Order[]> {
-  const response = await fetch(apiUrl(`/api/v1/orders?wallet_id=${walletID}`), {
-    cache: "no-store"
+export async function fetchOrders(token: string): Promise<Order[]> {
+  const response = await fetch(apiUrl("/api/v1/orders"), {
+    cache: "no-store",
+    headers: authHeaders(token)
   });
   if (!response.ok) {
     throw new Error("Failed to load orders");
@@ -128,9 +170,10 @@ export async function fetchOrders(walletID: string): Promise<Order[]> {
   return data.orders;
 }
 
-export async function fetchActivity(walletID: string): Promise<ActivityLog[]> {
-  const response = await fetch(apiUrl(`/api/v1/activity?wallet_id=${walletID}`), {
-    cache: "no-store"
+export async function fetchActivity(token: string): Promise<ActivityLog[]> {
+  const response = await fetch(apiUrl("/api/v1/activity"), {
+    cache: "no-store",
+    headers: authHeaders(token)
   });
   if (!response.ok) {
     throw new Error("Failed to load activity");
@@ -141,20 +184,18 @@ export async function fetchActivity(walletID: string): Promise<ActivityLog[]> {
 }
 
 export async function placeMarketBuy(input: {
-  userID: string;
-  walletID: string;
   marketSymbol: string;
   quoteAmount: number;
   expectedPrice: number;
+  token: string;
 }) {
   const response = await fetch(apiUrl("/api/v1/orders"), {
     method: "POST",
     headers: {
-      "Content-Type": "application/json"
+      "Content-Type": "application/json",
+      ...authHeaders(input.token)
     },
     body: JSON.stringify({
-      user_id: input.userID,
-      wallet_id: input.walletID,
       market_symbol: input.marketSymbol,
       quote_amount: input.quoteAmount,
       expected_price: input.expectedPrice


### PR DESCRIPTION
## Summary
- add token-backed demo sessions and wallet ownership checks to protected APIs
- derive order and history access from the authenticated session instead of client supplied IDs
- create frontend demo sessions in the browser and reuse them from local storage

## Testing
- go test ./...
- npm.cmd test
- npm.cmd run build

Closes #12