### PR TITLE
Move demo order pricing to the server

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -29,7 +29,7 @@ func main() {
 	sessionRepository := postgres.NewDemoSessionRepository(db)
 
 	marketService := marketservice.NewService(marketRepository, cfg.MarketDataBaseURL)
-	orderService := orderservice.NewService(marketRepository, balanceRepository, portfolioRepository)
+	orderService := orderservice.NewService(marketRepository, balanceRepository, portfolioRepository, marketService)
 	portfolioService := portfolioservice.NewService(portfolioRepository)
 	historyService := historyservice.NewService(portfolioRepository)
 	sessionService := sessionservice.NewService(sessionRepository)

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -176,9 +176,8 @@ func NewRouter(markets MarketLister, marketCandles MarketCandlesLister, orders O
 		}
 
 		var payload struct {
-			MarketSymbol  string  `json:"market_symbol"`
-			QuoteAmount   float64 `json:"quote_amount"`
-			ExpectedPrice float64 `json:"expected_price"`
+			MarketSymbol string  `json:"market_symbol"`
+			QuoteAmount  float64 `json:"quote_amount"`
 		}
 
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -187,17 +186,16 @@ func NewRouter(markets MarketLister, marketCandles MarketCandlesLister, orders O
 		}
 
 		order, err := orders.PlaceMarketBuy(r.Context(), orderservice.PlaceMarketBuyInput{
-			UserID:        demoSession.UserID,
-			WalletID:      demoSession.WalletID,
-			MarketSymbol:  payload.MarketSymbol,
-			QuoteAmount:   payload.QuoteAmount,
-			ExpectedPrice: payload.ExpectedPrice,
+			UserID:       demoSession.UserID,
+			WalletID:     demoSession.WalletID,
+			MarketSymbol: payload.MarketSymbol,
+			QuoteAmount:  payload.QuoteAmount,
 		})
 		if err != nil {
 			statusCode := http.StatusInternalServerError
 
 			switch {
-			case errors.Is(err, orderservice.ErrQuoteAmountTooLow), errors.Is(err, orderservice.ErrExpectedPriceLow):
+			case errors.Is(err, orderservice.ErrQuoteAmountTooLow), errors.Is(err, orderservice.ErrCurrentPriceUnavailable):
 				statusCode = http.StatusBadRequest
 			case errors.Is(err, orderservice.ErrInsufficientFunds):
 				statusCode = http.StatusUnprocessableEntity

--- a/backend/internal/http/router_test.go
+++ b/backend/internal/http/router_test.go
@@ -160,7 +160,7 @@ func TestListMarketCandlesRoute(t *testing.T) {
 }
 
 func TestCreateOrderRoute(t *testing.T) {
-	body := bytes.NewBufferString(`{"market_symbol":"XRP/USDT","quote_amount":50,"expected_price":0.67}`)
+	body := bytes.NewBufferString(`{"market_symbol":"XRP/USDT","quote_amount":50}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/orders", body)
 	req.Header.Set("Authorization", "Bearer token-1")
 	recorder := httptest.NewRecorder()

--- a/backend/internal/service/market/service.go
+++ b/backend/internal/service/market/service.go
@@ -34,6 +34,46 @@ func (s *Service) List(ctx context.Context) ([]domain.Market, error) {
 	return s.markets.List(ctx)
 }
 
+func (s *Service) GetSpotPrice(ctx context.Context, marketSymbol string) (float64, error) {
+	market, err := s.markets.GetBySymbol(ctx, marketSymbol)
+	if err != nil {
+		return 0, fmt.Errorf("get market: %w", err)
+	}
+
+	query := url.Values{}
+	query.Set("symbol", strings.ReplaceAll(market.Symbol, "/", ""))
+
+	endpoint := fmt.Sprintf("%s/api/v3/ticker/price?%s", s.marketDataBaseURL, query.Encode())
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return 0, fmt.Errorf("create market price request: %w", err)
+	}
+
+	response, err := s.client.Do(request)
+	if err != nil {
+		return 0, fmt.Errorf("request market price: %w", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("market price request failed with status %d", response.StatusCode)
+	}
+
+	var payload struct {
+		Price string `json:"price"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		return 0, fmt.Errorf("decode market price: %w", err)
+	}
+
+	price, err := strconv.ParseFloat(payload.Price, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse market price: %w", err)
+	}
+
+	return price, nil
+}
+
 func (s *Service) ListCandles(ctx context.Context, marketSymbol string, interval string, limit int) ([]domain.Candle, error) {
 	if interval == "" {
 		interval = "1h"

--- a/backend/internal/service/market/service_test.go
+++ b/backend/internal/service/market/service_test.go
@@ -59,6 +59,41 @@ func TestListCandlesFetchesRemoteMarketData(t *testing.T) {
 	}
 }
 
+func TestGetSpotPriceFetchesRemoteMarketPrice(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v3/ticker/price" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+
+		if got := r.URL.Query().Get("symbol"); got != "XRPUSDT" {
+			t.Fatalf("expected symbol XRPUSDT, got %s", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"symbol":"XRPUSDT","price":"0.6543"}`))
+	}))
+	defer server.Close()
+
+	service := NewService(fakeMarketRepository{
+		market: domain.Market{
+			ID:         "market-1",
+			Symbol:     "XRP/USDT",
+			BaseAsset:  "XRP",
+			QuoteAsset: "USDT",
+		},
+	}, server.URL)
+	service.client = server.Client()
+
+	price, err := service.GetSpotPrice(context.Background(), "XRP/USDT")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if price != 0.6543 {
+		t.Fatalf("expected price 0.6543, got %f", price)
+	}
+}
+
 type fakeMarketRepository struct {
 	market  domain.Market
 	markets []domain.Market

--- a/backend/internal/service/order/service.go
+++ b/backend/internal/service/order/service.go
@@ -13,9 +13,9 @@ import (
 )
 
 var (
-	ErrQuoteAmountTooLow = errors.New("quote amount must be greater than zero")
-	ErrExpectedPriceLow  = errors.New("expected price must be greater than zero")
-	ErrInsufficientFunds = errors.New("insufficient quote balance")
+	ErrQuoteAmountTooLow       = errors.New("quote amount must be greater than zero")
+	ErrCurrentPriceUnavailable = errors.New("current market price is unavailable")
+	ErrInsufficientFunds       = errors.New("insufficient quote balance")
 )
 
 type Clock interface {
@@ -32,33 +32,34 @@ type Service struct {
 	markets  store.MarketRepository
 	balances store.BalanceRepository
 	orders   store.PortfolioRepository
+	prices   PriceProvider
 	clock    Clock
 }
 
-func NewService(markets store.MarketRepository, balances store.BalanceRepository, orders store.PortfolioRepository) *Service {
+type PriceProvider interface {
+	GetSpotPrice(ctx context.Context, marketSymbol string) (float64, error)
+}
+
+func NewService(markets store.MarketRepository, balances store.BalanceRepository, orders store.PortfolioRepository, prices PriceProvider) *Service {
 	return &Service{
 		markets:  markets,
 		balances: balances,
 		orders:   orders,
+		prices:   prices,
 		clock:    realClock{},
 	}
 }
 
 type PlaceMarketBuyInput struct {
-	UserID        string
-	WalletID      string
-	MarketSymbol  string
-	QuoteAmount   float64
-	ExpectedPrice float64
+	UserID       string
+	WalletID     string
+	MarketSymbol string
+	QuoteAmount  float64
 }
 
 func (s *Service) PlaceMarketBuy(ctx context.Context, input PlaceMarketBuyInput) (domain.Order, error) {
 	if input.QuoteAmount <= 0 {
 		return domain.Order{}, ErrQuoteAmountTooLow
-	}
-
-	if input.ExpectedPrice <= 0 {
-		return domain.Order{}, ErrExpectedPriceLow
 	}
 
 	market, err := s.markets.GetBySymbol(ctx, input.MarketSymbol)
@@ -79,6 +80,15 @@ func (s *Service) PlaceMarketBuy(ctx context.Context, input PlaceMarketBuyInput)
 		return domain.Order{}, ErrInsufficientFunds
 	}
 
+	currentPrice, err := s.prices.GetSpotPrice(ctx, market.Symbol)
+	if err != nil {
+		return domain.Order{}, fmt.Errorf("get current price: %w", err)
+	}
+
+	if currentPrice <= 0 {
+		return domain.Order{}, ErrCurrentPriceUnavailable
+	}
+
 	order := domain.Order{
 		ID:            uuid.NewString(),
 		UserID:        input.UserID,
@@ -88,8 +98,8 @@ func (s *Service) PlaceMarketBuy(ctx context.Context, input PlaceMarketBuyInput)
 		BaseAsset:     market.BaseAsset,
 		QuoteAsset:    market.QuoteAsset,
 		QuoteAmount:   input.QuoteAmount,
-		BaseQuantity:  input.QuoteAmount / input.ExpectedPrice,
-		ExpectedPrice: input.ExpectedPrice,
+		BaseQuantity:  input.QuoteAmount / currentPrice,
+		ExpectedPrice: currentPrice,
 		Side:          domain.OrderSideBuy,
 		Type:          domain.OrderTypeMarket,
 		Status:        domain.OrderStatusFilled,

--- a/backend/internal/service/order/service_test.go
+++ b/backend/internal/service/order/service_test.go
@@ -24,22 +24,6 @@ func TestPlaceMarketBuyReturnsErrorForZeroQuoteAmount(t *testing.T) {
 	}
 }
 
-func TestPlaceMarketBuyReturnsErrorForZeroExpectedPrice(t *testing.T) {
-	service := &Service{}
-
-	_, err := service.PlaceMarketBuy(context.Background(), PlaceMarketBuyInput{
-		UserID:        "user-1",
-		WalletID:      "wallet-1",
-		MarketSymbol:  "XRP/USDT",
-		QuoteAmount:   10,
-		ExpectedPrice: 0,
-	})
-
-	if !errors.Is(err, ErrExpectedPriceLow) {
-		t.Fatalf("expected ErrExpectedPriceLow, got %v", err)
-	}
-}
-
 func TestPlaceMarketBuyReturnsErrorWhenFundsAreInsufficient(t *testing.T) {
 	service := NewService(
 		fakeMarketRepository{
@@ -58,14 +42,14 @@ func TestPlaceMarketBuyReturnsErrorWhenFundsAreInsufficient(t *testing.T) {
 			},
 		},
 		fakePortfolioRepository{},
+		fakePriceProvider{price: 0.65},
 	)
 
 	_, err := service.PlaceMarketBuy(context.Background(), PlaceMarketBuyInput{
-		UserID:        "user-1",
-		WalletID:      "wallet-1",
-		MarketSymbol:  "XRP/USDT",
-		QuoteAmount:   200,
-		ExpectedPrice: 0.65,
+		UserID:       "user-1",
+		WalletID:     "wallet-1",
+		MarketSymbol: "XRP/USDT",
+		QuoteAmount:  200,
 	})
 
 	if !errors.Is(err, ErrInsufficientFunds) {
@@ -93,15 +77,15 @@ func TestPlaceMarketBuyCreatesFilledOrder(t *testing.T) {
 			},
 		},
 		fakePortfolioRepository{},
+		fakePriceProvider{price: 0.67},
 	)
 	service.clock = fakeClock{now: now}
 
 	order, err := service.PlaceMarketBuy(context.Background(), PlaceMarketBuyInput{
-		UserID:        "user-1",
-		WalletID:      "wallet-1",
-		MarketSymbol:  "XRP/USDT",
-		QuoteAmount:   100,
-		ExpectedPrice: 0.67,
+		UserID:       "user-1",
+		WalletID:     "wallet-1",
+		MarketSymbol: "XRP/USDT",
+		QuoteAmount:  100,
 	})
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -117,6 +101,42 @@ func TestPlaceMarketBuyCreatesFilledOrder(t *testing.T) {
 
 	if !order.CreatedAt.Equal(now) {
 		t.Fatalf("expected created time %s, got %s", now, order.CreatedAt)
+	}
+
+	if order.ExpectedPrice != 0.67 {
+		t.Fatalf("expected server-side price 0.67, got %f", order.ExpectedPrice)
+	}
+}
+
+func TestPlaceMarketBuyReturnsErrorWhenPriceProviderHasNoPrice(t *testing.T) {
+	service := NewService(
+		fakeMarketRepository{
+			market: domain.Market{
+				ID:          "market-1",
+				Symbol:      "XRP/USDT",
+				BaseAsset:   "XRP",
+				QuoteAsset:  "USDT",
+				MinNotional: 10,
+			},
+		},
+		fakeBalanceRepository{
+			balance: domain.Balance{
+				AssetSymbol: "USDT",
+				Available:   500,
+			},
+		},
+		fakePortfolioRepository{},
+		fakePriceProvider{price: 0},
+	)
+
+	_, err := service.PlaceMarketBuy(context.Background(), PlaceMarketBuyInput{
+		UserID:       "user-1",
+		WalletID:     "wallet-1",
+		MarketSymbol: "XRP/USDT",
+		QuoteAmount:  100,
+	})
+	if !errors.Is(err, ErrCurrentPriceUnavailable) {
+		t.Fatalf("expected ErrCurrentPriceUnavailable, got %v", err)
 	}
 }
 
@@ -168,4 +188,13 @@ func (f fakePortfolioRepository) ListByWallet(context.Context, string, int) ([]d
 
 func (f fakePortfolioRepository) ListActivityByWallet(context.Context, string, int) ([]domain.ActivityLog, error) {
 	return nil, f.err
+}
+
+type fakePriceProvider struct {
+	price float64
+	err   error
+}
+
+func (f fakePriceProvider) GetSpotPrice(context.Context, string) (float64, error) {
+	return f.price, f.err
 }

--- a/frontend/components/market-dashboard.tsx
+++ b/frontend/components/market-dashboard.tsx
@@ -178,7 +178,6 @@ export function MarketDashboard() {
   const [selectedMarket, setSelectedMarket] = useState("XRP/USDT");
   const [selectedInterval, setSelectedInterval] = useState("1h");
   const [quoteAmount, setQuoteAmount] = useState("50");
-  const [expectedPrice, setExpectedPrice] = useState("0.67");
   const [isLoading, setIsLoading] = useState(true);
   const [isChartLoading, setIsChartLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -224,7 +223,6 @@ export function MarketDashboard() {
     setOrders(orderHistory);
     setActivity(activityHistory);
     setCandles(marketCandles);
-    setExpectedPrice(getLastItem(marketCandles)?.closePrice.toFixed(4) ?? "0.67");
     setIsChartLoading(false);
   }
 
@@ -273,8 +271,7 @@ export function MarketDashboard() {
       await placeMarketBuy({
         token: session.token,
         marketSymbol: selectedMarket,
-        quoteAmount: Number(quoteAmount),
-        expectedPrice: Number(expectedPrice)
+        quoteAmount: Number(quoteAmount)
       });
 
       await loadData(session);
@@ -413,12 +410,10 @@ export function MarketDashboard() {
                 </label>
 
                 <label className="grid gap-2 text-sm text-[var(--muted)]">
-                  Expected execution price
-                  <input
-                    value={expectedPrice}
-                    onChange={(event) => setExpectedPrice(event.target.value)}
-                    className="rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.6)] px-4 py-3 text-[var(--text)] outline-none"
-                  />
+                  Server-side execution pricing
+                  <div className="rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.6)] px-4 py-3 text-[var(--text)]">
+                    {latestCandle ? `${formatCurrency(latestCandle.closePrice)} estimated from live feed` : "Waiting for market data..."}
+                  </div>
                 </label>
 
                 <button

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -186,7 +186,6 @@ export async function fetchActivity(token: string): Promise<ActivityLog[]> {
 export async function placeMarketBuy(input: {
   marketSymbol: string;
   quoteAmount: number;
-  expectedPrice: number;
   token: string;
 }) {
   const response = await fetch(apiUrl("/api/v1/orders"), {
@@ -197,8 +196,7 @@ export async function placeMarketBuy(input: {
     },
     body: JSON.stringify({
       market_symbol: input.marketSymbol,
-      quote_amount: input.quoteAmount,
-      expected_price: input.expectedPrice
+      quote_amount: input.quoteAmount
     })
   });
 


### PR DESCRIPTION
## Summary
- fetch live market prices on the backend before demo order execution
- stop accepting client supplied expected prices in the API and frontend
- show server-side pricing as a live estimate in the trading ticket

## Testing
- go test ./...
- npm.cmd test
- npm.cmd run build

Closes #11