### PR TITLE
Harden market data and decouple dashboard refreshes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,10 @@ jobs:
 
       - name: Render production overlay
         run: kubectl kustomize deploy/kubernetes/overlays/production > /tmp/tradelab-prod.yaml
+
+      - name: Validate immutable release manifest rendering
+        run: |
+          chmod +x deploy/kubernetes/render-release-manifests.sh
+          ./deploy/kubernetes/render-release-manifests.sh v0.0.ci /tmp/tradelab-release.yaml
+          grep "ghcr.io/aidun/tradelab-backend:v0.0.ci" /tmp/tradelab-release.yaml
+          grep "ghcr.io/aidun/tradelab-frontend:v0.0.ci" /tmp/tradelab-release.yaml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,10 +244,17 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
 
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: v1.32.2
+
       - name: Package Kubernetes manifests
         run: |
           mkdir -p dist
-          tar -czf dist/tradelab-kubernetes.tar.gz -C deploy kubernetes
+          chmod +x deploy/kubernetes/render-release-manifests.sh
+          ./deploy/kubernetes/render-release-manifests.sh "${{ needs.release-metadata.outputs.tag }}" dist/tradelab-kubernetes.yaml
+          tar -czf dist/tradelab-kubernetes.tar.gz -C dist tradelab-kubernetes.yaml
 
       - name: Upload manifest artifact
         uses: actions/upload-artifact@v4

--- a/backend/internal/domain/market.go
+++ b/backend/internal/domain/market.go
@@ -22,3 +22,13 @@ type Candle struct {
 	QuoteVolume float64
 	Trades      int64
 }
+
+type MarketDataMeta struct {
+	Source      string    `json:"source"`
+	GeneratedAt time.Time `json:"generated_at"`
+}
+
+type CandleFeed struct {
+	Candles []Candle
+	Meta    MarketDataMeta
+}

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -19,7 +19,7 @@ type MarketLister interface {
 }
 
 type MarketCandlesLister interface {
-	ListCandles(ctx context.Context, marketSymbol string, interval string, limit int) ([]domain.Candle, error)
+	ListCandles(ctx context.Context, marketSymbol string, interval string, limit int) (domain.CandleFeed, error)
 }
 
 type OrderPlacer interface {
@@ -81,7 +81,7 @@ func NewRouter(markets MarketLister, marketCandles MarketCandlesLister, orders O
 			return
 		}
 
-		candles, err := marketCandles.ListCandles(
+		feed, err := marketCandles.ListCandles(
 			r.Context(),
 			marketSymbol,
 			r.URL.Query().Get("interval"),
@@ -92,7 +92,10 @@ func NewRouter(markets MarketLister, marketCandles MarketCandlesLister, orders O
 			return
 		}
 
-		writeJSON(w, http.StatusOK, map[string]any{"candles": candles})
+		writeJSON(w, http.StatusOK, map[string]any{
+			"candles": feed.Candles,
+			"meta":    feed.Meta,
+		})
 	})
 
 	mux.HandleFunc("POST /api/v1/sessions/demo", func(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/http/router_test.go
+++ b/backend/internal/http/router_test.go
@@ -144,9 +144,12 @@ func TestListMarketCandlesRoute(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
 	NewRouter(fakeMarketLister{}, fakeMarketLister{
-		candles: []domain.Candle{
-			{OpenPrice: 0.62, HighPrice: 0.64, LowPrice: 0.61, ClosePrice: 0.63},
-			{OpenPrice: 0.63, HighPrice: 0.65, LowPrice: 0.62, ClosePrice: 0.64},
+		feed: domain.CandleFeed{
+			Candles: []domain.Candle{
+				{OpenPrice: 0.62, HighPrice: 0.64, LowPrice: 0.61, ClosePrice: 0.63},
+				{OpenPrice: 0.63, HighPrice: 0.65, LowPrice: 0.62, ClosePrice: 0.64},
+			},
+			Meta: domain.MarketDataMeta{Source: "stale", GeneratedAt: time.Date(2026, 3, 29, 12, 0, 0, 0, time.UTC)},
 		},
 	}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}, fakeSessionManager{}).ServeHTTP(recorder, req)
 
@@ -156,6 +159,10 @@ func TestListMarketCandlesRoute(t *testing.T) {
 
 	if !strings.Contains(recorder.Body.String(), "\"candles\"") {
 		t.Fatalf("expected candles payload in response, got %s", recorder.Body.String())
+	}
+
+	if !strings.Contains(recorder.Body.String(), "\"source\":\"stale\"") {
+		t.Fatalf("expected stale candle metadata in response, got %s", recorder.Body.String())
 	}
 }
 
@@ -186,13 +193,13 @@ func TestCreateOrderRoute(t *testing.T) {
 
 type fakeMarketLister struct {
 	markets []domain.Market
-	candles []domain.Candle
+	feed    domain.CandleFeed
 	err     error
 }
 
 func (f fakeMarketLister) List(context.Context) ([]domain.Market, error) { return f.markets, f.err }
-func (f fakeMarketLister) ListCandles(context.Context, string, string, int) ([]domain.Candle, error) {
-	return f.candles, f.err
+func (f fakeMarketLister) ListCandles(context.Context, string, string, int) (domain.CandleFeed, error) {
+	return f.feed, f.err
 }
 
 type fakeOrderPlacer struct {

--- a/backend/internal/service/market/service.go
+++ b/backend/internal/service/market/service.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aidun/tradelab/backend/internal/domain"
@@ -18,7 +19,42 @@ type Service struct {
 	markets           store.MarketRepository
 	marketDataBaseURL string
 	client            *http.Client
+	clock             Clock
+	cacheMu           sync.RWMutex
+	spotCache         map[string]spotPriceCacheEntry
+	candleCache       map[string]candleCacheEntry
 }
+
+type Clock interface {
+	Now() time.Time
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time {
+	return time.Now().UTC()
+}
+
+type spotPriceCacheEntry struct {
+	price       float64
+	generatedAt time.Time
+	freshUntil  time.Time
+	staleUntil  time.Time
+}
+
+type candleCacheEntry struct {
+	candles     []domain.Candle
+	generatedAt time.Time
+	freshUntil  time.Time
+	staleUntil  time.Time
+}
+
+const (
+	spotPriceFreshTTL = 5 * time.Second
+	spotPriceStaleTTL = 30 * time.Second
+	candleFreshTTL    = 15 * time.Second
+	candleStaleTTL    = 2 * time.Minute
+)
 
 func NewService(markets store.MarketRepository, marketDataBaseURL string) *Service {
 	return &Service{
@@ -27,6 +63,9 @@ func NewService(markets store.MarketRepository, marketDataBaseURL string) *Servi
 		client: &http.Client{
 			Timeout: 10 * time.Second,
 		},
+		clock:       realClock{},
+		spotCache:   map[string]spotPriceCacheEntry{},
+		candleCache: map[string]candleCacheEntry{},
 	}
 }
 
@@ -40,41 +79,25 @@ func (s *Service) GetSpotPrice(ctx context.Context, marketSymbol string) (float6
 		return 0, fmt.Errorf("get market: %w", err)
 	}
 
-	query := url.Values{}
-	query.Set("symbol", strings.ReplaceAll(market.Symbol, "/", ""))
-
-	endpoint := fmt.Sprintf("%s/api/v3/ticker/price?%s", s.marketDataBaseURL, query.Encode())
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return 0, fmt.Errorf("create market price request: %w", err)
+	now := s.clock.Now()
+	if entry, ok := s.getSpotCacheEntry(market.Symbol); ok && now.Before(entry.freshUntil) {
+		return entry.price, nil
 	}
 
-	response, err := s.client.Do(request)
-	if err != nil {
-		return 0, fmt.Errorf("request market price: %w", err)
-	}
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		return 0, fmt.Errorf("market price request failed with status %d", response.StatusCode)
+	price, generatedAt, err := s.fetchSpotPrice(ctx, market.Symbol)
+	if err == nil {
+		s.storeSpotCacheEntry(market.Symbol, price, generatedAt)
+		return price, nil
 	}
 
-	var payload struct {
-		Price string `json:"price"`
-	}
-	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
-		return 0, fmt.Errorf("decode market price: %w", err)
+	if entry, ok := s.getSpotCacheEntry(market.Symbol); ok && now.Before(entry.staleUntil) {
+		return entry.price, nil
 	}
 
-	price, err := strconv.ParseFloat(payload.Price, 64)
-	if err != nil {
-		return 0, fmt.Errorf("parse market price: %w", err)
-	}
-
-	return price, nil
+	return 0, err
 }
 
-func (s *Service) ListCandles(ctx context.Context, marketSymbol string, interval string, limit int) ([]domain.Candle, error) {
+func (s *Service) ListCandles(ctx context.Context, marketSymbol string, interval string, limit int) (domain.CandleFeed, error) {
 	if interval == "" {
 		interval = "1h"
 	}
@@ -85,45 +108,168 @@ func (s *Service) ListCandles(ctx context.Context, marketSymbol string, interval
 
 	market, err := s.markets.GetBySymbol(ctx, marketSymbol)
 	if err != nil {
-		return nil, fmt.Errorf("get market: %w", err)
+		return domain.CandleFeed{}, fmt.Errorf("get market: %w", err)
 	}
 
+	cacheKey := candleCacheKey(market.Symbol, interval, limit)
+	now := s.clock.Now()
+	if entry, ok := s.getCandleCacheEntry(cacheKey); ok && now.Before(entry.freshUntil) {
+		return domain.CandleFeed{
+			Candles: cloneCandles(entry.candles),
+			Meta: domain.MarketDataMeta{
+				Source:      "fresh",
+				GeneratedAt: entry.generatedAt,
+			},
+		}, nil
+	}
+
+	candles, generatedAt, err := s.fetchCandles(ctx, market.Symbol, interval, limit)
+	if err == nil {
+		s.storeCandleCacheEntry(cacheKey, candles, generatedAt)
+		return domain.CandleFeed{
+			Candles: candles,
+			Meta: domain.MarketDataMeta{
+				Source:      "fresh",
+				GeneratedAt: generatedAt,
+			},
+		}, nil
+	}
+
+	if entry, ok := s.getCandleCacheEntry(cacheKey); ok && now.Before(entry.staleUntil) {
+		return domain.CandleFeed{
+			Candles: cloneCandles(entry.candles),
+			Meta: domain.MarketDataMeta{
+				Source:      "stale",
+				GeneratedAt: entry.generatedAt,
+			},
+		}, nil
+	}
+
+	return domain.CandleFeed{}, err
+}
+
+func (s *Service) fetchSpotPrice(ctx context.Context, marketSymbol string) (float64, time.Time, error) {
 	query := url.Values{}
-	query.Set("symbol", strings.ReplaceAll(market.Symbol, "/", ""))
+	query.Set("symbol", strings.ReplaceAll(marketSymbol, "/", ""))
+
+	endpoint := fmt.Sprintf("%s/api/v3/ticker/price?%s", s.marketDataBaseURL, query.Encode())
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return 0, time.Time{}, fmt.Errorf("create market price request: %w", err)
+	}
+
+	response, err := s.client.Do(request)
+	if err != nil {
+		return 0, time.Time{}, fmt.Errorf("request market price: %w", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return 0, time.Time{}, fmt.Errorf("market price request failed with status %d", response.StatusCode)
+	}
+
+	var payload struct {
+		Price string `json:"price"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		return 0, time.Time{}, fmt.Errorf("decode market price: %w", err)
+	}
+
+	price, err := strconv.ParseFloat(payload.Price, 64)
+	if err != nil {
+		return 0, time.Time{}, fmt.Errorf("parse market price: %w", err)
+	}
+
+	return price, s.clock.Now(), nil
+}
+
+func (s *Service) fetchCandles(ctx context.Context, marketSymbol string, interval string, limit int) ([]domain.Candle, time.Time, error) {
+	query := url.Values{}
+	query.Set("symbol", strings.ReplaceAll(marketSymbol, "/", ""))
 	query.Set("interval", interval)
 	query.Set("limit", strconv.Itoa(limit))
 
 	endpoint := fmt.Sprintf("%s/api/v3/uiKlines?%s", s.marketDataBaseURL, query.Encode())
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
-		return nil, fmt.Errorf("create market data request: %w", err)
+		return nil, time.Time{}, fmt.Errorf("create market data request: %w", err)
 	}
 
 	response, err := s.client.Do(request)
 	if err != nil {
-		return nil, fmt.Errorf("request market data: %w", err)
+		return nil, time.Time{}, fmt.Errorf("request market data: %w", err)
 	}
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("market data request failed with status %d", response.StatusCode)
+		return nil, time.Time{}, fmt.Errorf("market data request failed with status %d", response.StatusCode)
 	}
 
 	var payload [][]any
 	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
-		return nil, fmt.Errorf("decode market data: %w", err)
+		return nil, time.Time{}, fmt.Errorf("decode market data: %w", err)
 	}
 
 	candles := make([]domain.Candle, 0, len(payload))
 	for _, row := range payload {
 		candle, err := parseCandle(row)
 		if err != nil {
-			return nil, err
+			return nil, time.Time{}, err
 		}
 		candles = append(candles, candle)
 	}
 
-	return candles, nil
+	return candles, s.clock.Now(), nil
+}
+
+func candleCacheKey(symbol string, interval string, limit int) string {
+	return fmt.Sprintf("%s|%s|%d", symbol, interval, limit)
+}
+
+func cloneCandles(candles []domain.Candle) []domain.Candle {
+	items := make([]domain.Candle, len(candles))
+	copy(items, candles)
+	return items
+}
+
+func (s *Service) getSpotCacheEntry(key string) (spotPriceCacheEntry, bool) {
+	s.cacheMu.RLock()
+	defer s.cacheMu.RUnlock()
+
+	entry, ok := s.spotCache[key]
+	return entry, ok
+}
+
+func (s *Service) storeSpotCacheEntry(key string, price float64, generatedAt time.Time) {
+	s.cacheMu.Lock()
+	defer s.cacheMu.Unlock()
+
+	s.spotCache[key] = spotPriceCacheEntry{
+		price:       price,
+		generatedAt: generatedAt,
+		freshUntil:  generatedAt.Add(spotPriceFreshTTL),
+		staleUntil:  generatedAt.Add(spotPriceStaleTTL),
+	}
+}
+
+func (s *Service) getCandleCacheEntry(key string) (candleCacheEntry, bool) {
+	s.cacheMu.RLock()
+	defer s.cacheMu.RUnlock()
+
+	entry, ok := s.candleCache[key]
+	return entry, ok
+}
+
+func (s *Service) storeCandleCacheEntry(key string, candles []domain.Candle, generatedAt time.Time) {
+	s.cacheMu.Lock()
+	defer s.cacheMu.Unlock()
+
+	s.candleCache[key] = candleCacheEntry{
+		candles:     cloneCandles(candles),
+		generatedAt: generatedAt,
+		freshUntil:  generatedAt.Add(candleFreshTTL),
+		staleUntil:  generatedAt.Add(candleStaleTTL),
+	}
 }
 
 func parseCandle(row []any) (domain.Candle, error) {

--- a/backend/internal/service/market/service_test.go
+++ b/backend/internal/service/market/service_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/aidun/tradelab/backend/internal/domain"
 )
@@ -44,18 +46,140 @@ func TestListCandlesFetchesRemoteMarketData(t *testing.T) {
 		},
 	}, server.URL)
 	service.client = server.Client()
+	service.clock = fakeClock{now: time.Date(2026, 3, 29, 12, 0, 0, 0, time.UTC)}
 
-	candles, err := service.ListCandles(context.Background(), "XRP/USDT", "1h", 48)
+	feed, err := service.ListCandles(context.Background(), "XRP/USDT", "1h", 48)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if len(candles) != 2 {
-		t.Fatalf("expected 2 candles, got %d", len(candles))
+	if len(feed.Candles) != 2 {
+		t.Fatalf("expected 2 candles, got %d", len(feed.Candles))
 	}
 
-	if candles[1].ClosePrice != 0.641 {
-		t.Fatalf("expected close price 0.641, got %f", candles[1].ClosePrice)
+	if feed.Candles[1].ClosePrice != 0.641 {
+		t.Fatalf("expected close price 0.641, got %f", feed.Candles[1].ClosePrice)
+	}
+
+	if feed.Meta.Source != "fresh" {
+		t.Fatalf("expected fresh source, got %s", feed.Meta.Source)
+	}
+}
+
+func TestListCandlesUsesFreshCache(t *testing.T) {
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			[1743242400000, "0.6200", "0.6400", "0.6150", "0.6320", "1250000.0", 1743245999999, "789000.0", 8342, "0", "0", "0"]
+		]`))
+	}))
+	defer server.Close()
+
+	service := NewService(fakeMarketRepository{market: demoMarket()}, server.URL)
+	service.client = server.Client()
+	clock := &stepClock{times: []time.Time{
+		time.Date(2026, 3, 29, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, 3, 29, 12, 0, 5, 0, time.UTC),
+		time.Date(2026, 3, 29, 12, 0, 10, 0, time.UTC),
+	}}
+	service.clock = clock
+
+	first, err := service.ListCandles(context.Background(), "XRP/USDT", "1h", 48)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	second, err := service.ListCandles(context.Background(), "XRP/USDT", "1h", 48)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if atomic.LoadInt32(&calls) != 1 {
+		t.Fatalf("expected one upstream call, got %d", calls)
+	}
+
+	if second.Meta.Source != "fresh" {
+		t.Fatalf("expected fresh source from cache, got %s", second.Meta.Source)
+	}
+
+	if first.Meta.GeneratedAt != second.Meta.GeneratedAt {
+		t.Fatalf("expected cached generated time to match")
+	}
+}
+
+func TestListCandlesFallsBackToStaleCacheOnUpstreamFailure(t *testing.T) {
+	var shouldFail atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if shouldFail.Load() {
+			http.Error(w, "upstream unavailable", http.StatusBadGateway)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			[1743242400000, "0.6200", "0.6400", "0.6150", "0.6320", "1250000.0", 1743245999999, "789000.0", 8342, "0", "0", "0"]
+		]`))
+	}))
+	defer server.Close()
+
+	service := NewService(fakeMarketRepository{market: demoMarket()}, server.URL)
+	service.client = server.Client()
+	clock := &stepClock{times: []time.Time{
+		time.Date(2026, 3, 29, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, 3, 29, 12, 0, 1, 0, time.UTC),
+		time.Date(2026, 3, 29, 12, 0, 20, 0, time.UTC),
+		time.Date(2026, 3, 29, 12, 0, 40, 0, time.UTC),
+	}}
+	service.clock = clock
+
+	if _, err := service.ListCandles(context.Background(), "XRP/USDT", "1h", 48); err != nil {
+		t.Fatalf("expected initial fetch to succeed, got %v", err)
+	}
+
+	shouldFail.Store(true)
+
+	feed, err := service.ListCandles(context.Background(), "XRP/USDT", "1h", 48)
+	if err != nil {
+		t.Fatalf("expected stale fallback, got %v", err)
+	}
+
+	if feed.Meta.Source != "stale" {
+		t.Fatalf("expected stale source, got %s", feed.Meta.Source)
+	}
+}
+
+func TestListCandlesReturnsErrorWhenNoFallbackIsAvailable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream unavailable", http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	service := NewService(fakeMarketRepository{market: demoMarket()}, server.URL)
+	service.client = server.Client()
+	service.clock = fakeClock{now: time.Date(2026, 3, 29, 12, 0, 0, 0, time.UTC)}
+
+	_, err := service.ListCandles(context.Background(), "XRP/USDT", "1h", 48)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+}
+
+func TestListCandlesReturnsErrorForMalformedPayloadWithoutFallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"invalid":true}`))
+	}))
+	defer server.Close()
+
+	service := NewService(fakeMarketRepository{market: demoMarket()}, server.URL)
+	service.client = server.Client()
+	service.clock = fakeClock{now: time.Date(2026, 3, 29, 12, 0, 0, 0, time.UTC)}
+
+	_, err := service.ListCandles(context.Background(), "XRP/USDT", "1h", 48)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
 	}
 }
 
@@ -74,15 +198,9 @@ func TestGetSpotPriceFetchesRemoteMarketPrice(t *testing.T) {
 	}))
 	defer server.Close()
 
-	service := NewService(fakeMarketRepository{
-		market: domain.Market{
-			ID:         "market-1",
-			Symbol:     "XRP/USDT",
-			BaseAsset:  "XRP",
-			QuoteAsset: "USDT",
-		},
-	}, server.URL)
+	service := NewService(fakeMarketRepository{market: demoMarket()}, server.URL)
 	service.client = server.Client()
+	service.clock = fakeClock{now: time.Date(2026, 3, 29, 12, 0, 0, 0, time.UTC)}
 
 	price, err := service.GetSpotPrice(context.Background(), "XRP/USDT")
 	if err != nil {
@@ -91,6 +209,90 @@ func TestGetSpotPriceFetchesRemoteMarketPrice(t *testing.T) {
 
 	if price != 0.6543 {
 		t.Fatalf("expected price 0.6543, got %f", price)
+	}
+}
+
+func TestGetSpotPriceUsesFreshCacheAndStaleFallback(t *testing.T) {
+	var calls int32
+	var shouldFail atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		if shouldFail.Load() {
+			http.Error(w, "upstream unavailable", http.StatusBadGateway)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"symbol":"XRPUSDT","price":"0.6543"}`))
+	}))
+	defer server.Close()
+
+	service := NewService(fakeMarketRepository{market: demoMarket()}, server.URL)
+	service.client = server.Client()
+	clock := &stepClock{times: []time.Time{
+		time.Date(2026, 3, 29, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, 3, 29, 12, 0, 1, 0, time.UTC),
+		time.Date(2026, 3, 29, 12, 0, 7, 0, time.UTC),
+		time.Date(2026, 3, 29, 12, 0, 20, 0, time.UTC),
+	}}
+	service.clock = clock
+
+	first, err := service.GetSpotPrice(context.Background(), "XRP/USDT")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	second, err := service.GetSpotPrice(context.Background(), "XRP/USDT")
+	if err != nil {
+		t.Fatalf("expected cached price, got %v", err)
+	}
+
+	shouldFail.Store(true)
+
+	third, err := service.GetSpotPrice(context.Background(), "XRP/USDT")
+	if err != nil {
+		t.Fatalf("expected stale fallback, got %v", err)
+	}
+
+	if atomic.LoadInt32(&calls) != 2 {
+		t.Fatalf("expected two upstream calls, got %d", calls)
+	}
+
+	if first != second || second != third {
+		t.Fatalf("expected cached values to match")
+	}
+}
+
+func TestGetSpotPriceReturnsErrorAfterStaleWindowExpires(t *testing.T) {
+	var shouldFail atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if shouldFail.Load() {
+			http.Error(w, "upstream unavailable", http.StatusBadGateway)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"symbol":"XRPUSDT","price":"0.6543"}`))
+	}))
+	defer server.Close()
+
+	service := NewService(fakeMarketRepository{market: demoMarket()}, server.URL)
+	service.client = server.Client()
+	clock := &stepClock{times: []time.Time{
+		time.Date(2026, 3, 29, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, 3, 29, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, 3, 29, 12, 0, 40, 0, time.UTC),
+	}}
+	service.clock = clock
+
+	if _, err := service.GetSpotPrice(context.Background(), "XRP/USDT"); err != nil {
+		t.Fatalf("expected initial fetch to succeed, got %v", err)
+	}
+
+	shouldFail.Store(true)
+
+	if _, err := service.GetSpotPrice(context.Background(), "XRP/USDT"); err == nil {
+		t.Fatal("expected an error after stale window expiry, got nil")
 	}
 }
 
@@ -106,4 +308,37 @@ func (f fakeMarketRepository) List(context.Context) ([]domain.Market, error) {
 
 func (f fakeMarketRepository) GetBySymbol(context.Context, string) (domain.Market, error) {
 	return f.market, f.err
+}
+
+type fakeClock struct{ now time.Time }
+
+func (f fakeClock) Now() time.Time { return f.now }
+
+type stepClock struct {
+	times []time.Time
+	index int
+}
+
+func (c *stepClock) Now() time.Time {
+	if len(c.times) == 0 {
+		return time.Time{}
+	}
+
+	if c.index >= len(c.times) {
+		return c.times[len(c.times)-1]
+	}
+
+	value := c.times[c.index]
+	c.index++
+	return value
+}
+
+func demoMarket() domain.Market {
+	return domain.Market{
+		ID:          "market-1",
+		Symbol:      "XRP/USDT",
+		BaseAsset:   "XRP",
+		QuoteAsset:  "USDT",
+		MinNotional: 10,
+	}
 }

--- a/deploy/kubernetes/base/backend-deployment.yaml
+++ b/deploy/kubernetes/base/backend-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       initContainers:
         - name: migrate
-          image: ghcr.io/aidun/tradelab-backend:latest
+          image: ghcr.io/aidun/tradelab-backend:IMAGE_TAG_PLACEHOLDER
           imagePullPolicy: Always
           command:
             - /app/tradelab-migrate
@@ -27,7 +27,7 @@ spec:
                   key: DATABASE_URL
       containers:
         - name: api
-          image: ghcr.io/aidun/tradelab-backend:latest
+          image: ghcr.io/aidun/tradelab-backend:IMAGE_TAG_PLACEHOLDER
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/deploy/kubernetes/base/frontend-deployment.yaml
+++ b/deploy/kubernetes/base/frontend-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: web
-          image: ghcr.io/aidun/tradelab-frontend:latest
+          image: ghcr.io/aidun/tradelab-frontend:IMAGE_TAG_PLACEHOLDER
           imagePullPolicy: Always
           ports:
             - containerPort: 3000

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -12,9 +12,3 @@ resources:
   - frontend-service.yaml
   - frontend-deployment.yaml
   - ingress.yaml
-
-images:
-  - name: ghcr.io/aidun/tradelab-backend
-    newTag: latest
-  - name: ghcr.io/aidun/tradelab-frontend
-    newTag: latest

--- a/deploy/kubernetes/overlays/development/kustomization.yaml
+++ b/deploy/kubernetes/overlays/development/kustomization.yaml
@@ -15,5 +15,11 @@ secretGenerator:
 generatorOptions:
   disableNameSuffixHash: true
 
+images:
+  - name: ghcr.io/aidun/tradelab-backend
+    newTag: latest
+  - name: ghcr.io/aidun/tradelab-frontend
+    newTag: latest
+
 patches:
   - path: patch-ingress.yaml

--- a/deploy/kubernetes/render-release-manifests.sh
+++ b/deploy/kubernetes/render-release-manifests.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <release-tag> <output-file>" >&2
+  exit 1
+fi
+
+RELEASE_TAG="$1"
+OUTPUT_FILE="$2"
+
+kubectl kustomize deploy/kubernetes/overlays/production \
+  | sed "s/IMAGE_TAG_PLACEHOLDER/${RELEASE_TAG}/g" \
+  > "${OUTPUT_FILE}"
+
+if grep -q "IMAGE_TAG_PLACEHOLDER" "${OUTPUT_FILE}"; then
+  echo "placeholder tag still present in rendered manifests" >&2
+  exit 1
+fi
+
+if grep -q "ghcr.io/aidun/tradelab-.*:latest" "${OUTPUT_FILE}"; then
+  echo "mutable latest tag found in rendered release manifests" >&2
+  exit 1
+fi

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -19,7 +19,9 @@ Every successful `master` release publishes:
 - `ghcr.io/aidun/tradelab-frontend:latest`
 - `ghcr.io/aidun/tradelab-frontend:v0.1.<run-number>`
 
-The Kubernetes manifests default to the `latest` tags so a fresh release can be deployed without patching image references first.
+The release artifact packages Kubernetes manifests with immutable `v0.1.<run-number>` image tags. The
+development overlay keeps using `latest` for convenience, while release deployments should use the packaged
+manifest artifact or render production manifests through the release helper script.
 
 ## Layout
 
@@ -72,6 +74,13 @@ Then deploy:
 
 ```bash
 kubectl apply -k deploy/kubernetes/overlays/production
+```
+
+For immutable production output tied to a release tag, render the packaged manifest shape with:
+
+```bash
+./deploy/kubernetes/render-release-manifests.sh v0.1.123 /tmp/tradelab-kubernetes.yaml
+kubectl apply -f /tmp/tradelab-kubernetes.yaml
 ```
 
 ## Operational notes

--- a/frontend/__tests__/home.test.tsx
+++ b/frontend/__tests__/home.test.tsx
@@ -1,13 +1,24 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { Hero } from "@/components/hero";
 
 describe("Hero", () => {
+  const fetchCounts: Record<string, number> = {};
+
   beforeEach(() => {
+    for (const key of Object.keys(fetchCounts)) {
+      delete fetchCounts[key];
+    }
+
     vi.spyOn(global, "fetch").mockImplementation((input) => {
       const url = String(input);
 
+      function record(key: string) {
+        fetchCounts[key] = (fetchCounts[key] ?? 0) + 1;
+      }
+
       if (url.includes("/api/v1/sessions/demo")) {
+        record("session");
         return Promise.resolve(
           new Response(
             JSON.stringify({
@@ -24,6 +35,7 @@ describe("Hero", () => {
       }
 
       if (url.includes("/candles")) {
+        record(`candles:${url.includes("interval=15m") ? "15m" : "1h"}`);
         return Promise.resolve(
           new Response(
             JSON.stringify({
@@ -50,13 +62,18 @@ describe("Hero", () => {
                   quoteVolume: 896000,
                   trades: 9200
                 }
-              ]
+              ],
+              meta: {
+                source: url.includes("interval=15m") ? "stale" : "fresh",
+                generated_at: "2026-03-29T12:05:00Z"
+              }
             })
           )
         );
       }
 
       if (url.includes("/api/v1/markets")) {
+        record("markets");
         return Promise.resolve(
           new Response(
             JSON.stringify({
@@ -76,6 +93,7 @@ describe("Hero", () => {
       }
 
       if (url.includes("/api/v1/orders")) {
+        record("orders");
         return Promise.resolve(
           new Response(
             JSON.stringify({
@@ -96,6 +114,7 @@ describe("Hero", () => {
       }
 
       if (url.includes("/api/v1/activity")) {
+        record("activity");
         return Promise.resolve(
           new Response(
             JSON.stringify({
@@ -114,6 +133,7 @@ describe("Hero", () => {
         );
       }
 
+      record("portfolio");
       return Promise.resolve(
         new Response(
           JSON.stringify({
@@ -150,8 +170,31 @@ describe("Hero", () => {
       expect(screen.getAllByText(/xrp\/usdt/i)[0]).toBeInTheDocument();
     });
 
-    expect(screen.getByLabelText(/live market chart/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByLabelText(/live market chart/i)).toBeInTheDocument();
+    });
     expect(screen.getByText(/run demo buy/i)).toBeInTheDocument();
     expect(screen.getByText(/demo buy recorded/i)).toBeInTheDocument();
+  });
+
+  it("refreshes only chart data when the interval changes", async () => {
+    render(<Hero />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/feed fresh/i)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "15m" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/feed stale fallback/i)).toBeInTheDocument();
+    });
+
+    expect(fetchCounts["markets"]).toBe(1);
+    expect(fetchCounts["portfolio"]).toBe(1);
+    expect(fetchCounts["orders"]).toBe(1);
+    expect(fetchCounts["activity"]).toBe(1);
+    expect(fetchCounts["candles:1h"]).toBe(1);
+    expect(fetchCounts["candles:15m"]).toBe(1);
   });
 });

--- a/frontend/components/market-dashboard.tsx
+++ b/frontend/components/market-dashboard.tsx
@@ -11,8 +11,10 @@ import {
   placeMarketBuy,
   type ActivityLog,
   type Candle,
+  type CandleFeed,
   type DemoSession,
   type Market,
+  type MarketDataMeta,
   type Order,
   type PortfolioSummary
 } from "@/lib/api";
@@ -60,6 +62,14 @@ function getLastItem<T>(items: T[]) {
   }
 
   return items[items.length - 1];
+}
+
+function formatFeedTime(value: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit"
+  }).format(new Date(value));
 }
 
 function CandleChart({ candles }: { candles: Candle[] }) {
@@ -175,6 +185,7 @@ export function MarketDashboard() {
   const [orders, setOrders] = useState<Order[]>([]);
   const [activity, setActivity] = useState<ActivityLog[]>([]);
   const [candles, setCandles] = useState<Candle[]>([]);
+  const [chartMeta, setChartMeta] = useState<MarketDataMeta | null>(null);
   const [selectedMarket, setSelectedMarket] = useState("XRP/USDT");
   const [selectedInterval, setSelectedInterval] = useState("1h");
   const [quoteAmount, setQuoteAmount] = useState("50");
@@ -182,6 +193,7 @@ export function MarketDashboard() {
   const [isChartLoading, setIsChartLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [chartError, setChartError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
 
   async function ensureDemoSession() {
@@ -206,23 +218,29 @@ export function MarketDashboard() {
     return nextSession;
   }
 
-  async function loadData(activeSession: DemoSession) {
+  async function loadCoreData(activeSession: DemoSession) {
     setError(null);
-    setIsChartLoading(true);
 
-    const [marketList, portfolioSummary, orderHistory, activityHistory, marketCandles] = await Promise.all([
+    const [marketList, portfolioSummary, orderHistory, activityHistory] = await Promise.all([
       fetchMarkets(),
       fetchPortfolio(activeSession.walletID, activeSession.token),
       fetchOrders(activeSession.token),
-      fetchActivity(activeSession.token),
-      fetchCandles(selectedMarket, selectedInterval, 48)
+      fetchActivity(activeSession.token)
     ]);
 
     setMarkets(marketList);
     setPortfolio(portfolioSummary);
     setOrders(orderHistory);
     setActivity(activityHistory);
-    setCandles(marketCandles);
+  }
+
+  async function loadChartData() {
+    setChartError(null);
+    setIsChartLoading(true);
+
+    const feed: CandleFeed = await fetchCandles(selectedMarket, selectedInterval, 48);
+    setCandles(feed.candles);
+    setChartMeta(feed.meta);
     setIsChartLoading(false);
   }
 
@@ -237,12 +255,11 @@ export function MarketDashboard() {
           }
 
           setSession(activeSession);
-          return loadData(activeSession);
+          return loadCoreData(activeSession);
         })
         .catch((loadError: Error) => {
           if (!cancelled) {
             setError(loadError.message);
-            setIsChartLoading(false);
           }
         })
         .finally(() => {
@@ -255,7 +272,28 @@ export function MarketDashboard() {
     return () => {
       cancelled = true;
     };
-  }, [selectedInterval, selectedMarket]);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!session) {
+      return;
+    }
+
+    startTransition(() => {
+      loadChartData().catch((loadError: Error) => {
+        if (!cancelled) {
+          setChartError(loadError.message);
+          setIsChartLoading(false);
+        }
+      });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [session, selectedMarket, selectedInterval]);
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -274,7 +312,7 @@ export function MarketDashboard() {
         quoteAmount: Number(quoteAmount)
       });
 
-      await loadData(session);
+      await Promise.all([loadCoreData(session), loadChartData()]);
       setSuccess(`Demo buy executed for ${selectedMarket}.`);
     } catch (submitError) {
       setError(submitError instanceof Error ? submitError.message : "Order failed");
@@ -319,6 +357,12 @@ export function MarketDashboard() {
               <div className="flex items-center justify-between gap-8">
                 <span>Last price</span>
                 <span>{latestCandle ? formatCurrency(latestCandle.closePrice) : "--"}</span>
+              </div>
+              <div className="flex items-center justify-between gap-8">
+                <span>Feed state</span>
+                <span className={chartMeta?.source === "stale" ? "text-[var(--accent-hot)]" : "text-[var(--accent)]"}>
+                  {chartMeta?.source === "stale" ? "Stale" : "Fresh"}
+                </span>
               </div>
             </div>
           </div>
@@ -462,9 +506,24 @@ export function MarketDashboard() {
                 <div className="rounded-2xl border border-dashed border-[var(--line)] px-4 py-12 text-sm text-[var(--muted)]">
                   Loading candle data...
                 </div>
+              ) : chartError ? (
+                <div className="rounded-2xl border border-[rgba(255,107,120,0.35)] bg-[rgba(255,107,120,0.08)] px-4 py-12 text-sm text-[var(--accent-hot)]">
+                  {chartError}
+                </div>
               ) : (
                 <CandleChart candles={candles} />
               )}
+            </div>
+
+            <div className="mt-4 flex flex-wrap items-center gap-3 text-sm text-[var(--muted)]">
+              <span className="rounded-full border border-[var(--line)] px-3 py-2">
+                Feed {chartMeta?.source === "stale" ? "stale fallback" : "fresh"}
+              </span>
+              {chartMeta ? (
+                <span className="rounded-full border border-[var(--line)] px-3 py-2">
+                  Updated {formatFeedTime(chartMeta.generatedAt)}
+                </span>
+              ) : null}
             </div>
 
             <div className="mt-5 grid gap-3 md:grid-cols-3">

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -78,6 +78,16 @@ export type Candle = {
   trades: number;
 };
 
+export type MarketDataMeta = {
+  source: "fresh" | "stale";
+  generatedAt: string;
+};
+
+export type CandleFeed = {
+  candles: Candle[];
+  meta: MarketDataMeta;
+};
+
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
 
 function apiUrl(path: string) {
@@ -130,7 +140,7 @@ export async function fetchMarkets(): Promise<Market[]> {
   return data.markets;
 }
 
-export async function fetchCandles(marketSymbol: string, interval = "1h", limit = 48): Promise<Candle[]> {
+export async function fetchCandles(marketSymbol: string, interval = "1h", limit = 48): Promise<CandleFeed> {
   const encodedSymbol = encodeURIComponent(marketSymbol);
   const response = await fetch(apiUrl(`/api/v1/markets/${encodedSymbol}/candles?interval=${interval}&limit=${limit}`), {
     cache: "no-store"
@@ -140,7 +150,13 @@ export async function fetchCandles(marketSymbol: string, interval = "1h", limit 
   }
 
   const data = await response.json();
-  return data.candles;
+  return {
+    candles: data.candles,
+    meta: {
+      source: data.meta.source,
+      generatedAt: data.meta.generated_at ?? data.meta.generatedAt
+    }
+  };
 }
 
 export async function fetchPortfolio(walletID: string, token: string): Promise<PortfolioSummary> {


### PR DESCRIPTION
## Summary
- add short-lived market data caches with stale fallback metadata for candles and spot prices
- decouple dashboard chart refreshes from the wallet and history data flow
- package immutable Kubernetes release manifests and validate them in CI

## Testing
- go test ./...
- npm.cmd test
- npm.cmd run build
- .\\.tools\\kubectl.exe kustomize deploy\\kubernetes\\overlays\\development
- .\\.tools\\kubectl.exe kustomize deploy\\kubernetes\\overlays\\production
- bash deploy/kubernetes/render-release-manifests.sh v0.0.test /tmp/tradelab-kubernetes.yaml

Closes #13
Closes #15