### PR TITLE
Add user, system, and developer documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,50 @@
 # TradeLab
 
-TradeLab is a multi-asset crypto paper-trading platform with automated strategy support, backtesting, and a polished web experience. XRP is the reference market for the first user flows, but the platform is designed for multiple assets from day one.
+TradeLab is a multi-asset crypto paper-trading platform for demo execution, strategy experimentation, and trading workflow validation. XRP is the reference market for the first experience, but the platform is intentionally built for multiple assets.
 
-## Stack
+> [!IMPORTANT]
+> This repository includes AI-assisted code and documentation. TradeLab is an educational and simulation-oriented software project. It does not provide financial advice, investment recommendations, or trading guarantees, and it must not be treated as a substitute for independent financial decision-making.
 
-- Frontend: Next.js, TypeScript, Tailwind CSS
-- Backend: Go
-- Database: PostgreSQL
-- Testing: Go test, Vitest, React Testing Library, Playwright
+## Product overview
+
+TradeLab is designed to help users:
+
+- explore crypto markets with virtual balances
+- test execution and portfolio flows without risking real funds
+- understand automated strategy behavior in a transparent UI
+- evolve toward a production-grade trading sandbox with strong testing and operational discipline
+
+The current system is still a demo environment. It is not a live brokerage, not a custody product, and not a managed investment service.
+
+## Current capabilities
+
+- multi-asset market list with XRP as the default showcase market
+- demo-session based trading flow with isolated demo wallets
+- server-authoritative market-buy execution in the Go backend
+- portfolio, balances, orders, and activity history
+- market candle rendering with cached market-data fallback behavior
+- Kubernetes deployment assets and release automation
+
+## Quick links
+
+- Users and first-time readers:
+  [README](README.md),
+  [PRD.md](docs/PRD.md)
+- Operators:
+  [system-operations.md](docs/system-operations.md),
+  [deployment.md](docs/deployment.md)
+- Developers:
+  [developer-guide.md](docs/developer-guide.md),
+  [data-model.md](docs/data-model.md)
+- AI tooling / structured metadata:
+  [ai-metadata.json](docs/ai-metadata.json)
 
 ## Repository layout
 
 - `frontend/` web application
-- `backend/` API, domain logic, repositories, migrations
-- `deploy/` Kubernetes deployment manifests and overlays
-- `docs/` product and architecture documentation
+- `backend/` API, domain logic, repositories, and migrations
+- `deploy/` Kubernetes manifests and release-render helpers
+- `docs/` product, operational, developer, and machine-readable documentation
 
 ## Local development
 
@@ -45,13 +75,6 @@ cd frontend
 npm run dev
 ```
 
-### Build container images locally
-
-```bash
-docker build -f backend/Dockerfile -t tradelab-backend:local .
-docker build -f frontend/Dockerfile -t tradelab-frontend:local .
-```
-
 ## Testing
 
 ### Backend
@@ -59,41 +82,6 @@ docker build -f frontend/Dockerfile -t tradelab-frontend:local .
 ```bash
 cd backend
 go test ./...
-```
-
-### Demo seed identifiers
-
-- Demo user ID: `cfbf7c8f-eaf9-47fa-8674-2a29fed1fcc9`
-- Demo wallet ID: `1ddb1c1c-827f-4bf0-b85a-3d5786c3b26c`
-
-### Sample API calls
-
-```bash
-curl http://localhost:8080/api/v1/markets
-```
-
-```bash
-curl http://localhost:8080/api/v1/portfolios/1ddb1c1c-827f-4bf0-b85a-3d5786c3b26c
-```
-
-```bash
-curl "http://localhost:8080/api/v1/orders?wallet_id=1ddb1c1c-827f-4bf0-b85a-3d5786c3b26c"
-```
-
-```bash
-curl "http://localhost:8080/api/v1/activity?wallet_id=1ddb1c1c-827f-4bf0-b85a-3d5786c3b26c"
-```
-
-```bash
-curl -X POST http://localhost:8080/api/v1/orders \
-  -H "Content-Type: application/json" \
-  -d '{
-    "user_id": "cfbf7c8f-eaf9-47fa-8674-2a29fed1fcc9",
-    "wallet_id": "1ddb1c1c-827f-4bf0-b85a-3d5786c3b26c",
-    "market_symbol": "XRP/USDT",
-    "quote_amount": 50,
-    "expected_price": 0.67
-  }'
 ```
 
 ### Frontend unit tests
@@ -110,22 +98,59 @@ cd frontend
 npm run test:e2e
 ```
 
-## Kubernetes deployment
+## Sample API flow
 
-TradeLab ships with a complete Kubernetes deployment under `deploy/kubernetes`.
-
-Quick start for the development overlay:
+Create a demo session:
 
 ```bash
-kubectl apply -k deploy/kubernetes/overlays/development
+curl -X POST http://localhost:8080/api/v1/sessions/demo
 ```
 
-This deploys PostgreSQL, the Go backend, the Next.js frontend, and an ingress that routes `/api` to the backend and `/` to the frontend.
+Use the returned bearer token to access protected routes:
 
-Full deployment notes live in [docs/deployment.md](docs/deployment.md).
+```bash
+curl http://localhost:8080/api/v1/markets
+```
+
+```bash
+curl "http://localhost:8080/api/v1/markets/XRP%2FUSDT/candles?interval=1h&limit=48"
+```
+
+Use the `wallet_id` returned by the demo session for portfolio access:
+
+```bash
+curl http://localhost:8080/api/v1/portfolios/<wallet-id> \
+  -H "Authorization: Bearer <demo-token>"
+```
+
+```bash
+curl http://localhost:8080/api/v1/orders \
+  -H "Authorization: Bearer <demo-token>"
+```
+
+```bash
+curl -X POST http://localhost:8080/api/v1/orders \
+  -H "Authorization: Bearer <demo-token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "market_symbol": "XRP/USDT",
+    "quote_amount": 50
+  }'
+```
+
+## Deployment and delivery
+
+TradeLab ships with Kubernetes deployment assets, immutable release-manifest rendering, GitHub Actions CI, and GitHub release automation.
+
+- Deployment quick start:
+  [deployment.md](docs/deployment.md)
+- Runtime and operations guide:
+  [system-operations.md](docs/system-operations.md)
+- Contributor workflow:
+  [developer-guide.md](docs/developer-guide.md)
 
 ## Delivery automation
 
-- Pull requests are validated by GitHub Actions.
-- Successful PR checks can be auto-merged into `master`.
-- Every successful `master` run builds release artifacts, publishes container images to GitHub Container Registry, and creates a GitHub Release.
+- pull requests are validated by GitHub Actions
+- successful PR checks can be auto-merged into `master`
+- successful `master` runs publish release artifacts, container images, and a GitHub Release

--- a/docs/ai-metadata.json
+++ b/docs/ai-metadata.json
@@ -1,0 +1,75 @@
+{
+  "project": {
+    "name": "TradeLab",
+    "summary": "TradeLab is a multi-asset crypto paper-trading platform for demo execution, strategy experimentation, and trading workflow validation.",
+    "reference_market": "XRP/USDT",
+    "status": "demo-only",
+    "financial_advice": false,
+    "ai_assisted_repository": true
+  },
+  "stack": {
+    "frontend": ["Next.js", "TypeScript", "Tailwind CSS"],
+    "backend": ["Go"],
+    "database": ["PostgreSQL"],
+    "testing": ["go test", "Vitest", "React Testing Library", "Playwright"],
+    "deployment": ["Kubernetes", "GitHub Actions", "GitHub Container Registry"]
+  },
+  "directories": {
+    "frontend": "frontend/",
+    "backend": "backend/",
+    "deploy": "deploy/",
+    "docs": "docs/"
+  },
+  "runtime_components": [
+    "frontend web application",
+    "backend API",
+    "postgres database",
+    "ingress routing",
+    "migration init container",
+    "GitHub release and image publication pipeline"
+  ],
+  "key_workflows": [
+    "demo session creation",
+    "authenticated paper-trading API access",
+    "server-authoritative market buy execution",
+    "market-data fetch with bounded stale fallback",
+    "PR-first CI validation",
+    "master-triggered release automation",
+    "immutable release manifest rendering"
+  ],
+  "documentation": {
+    "readme": "README.md",
+    "product": "docs/PRD.md",
+    "data_model": "docs/data-model.md",
+    "deployment": "docs/deployment.md",
+    "system_operations": "docs/system-operations.md",
+    "developer_guide": "docs/developer-guide.md"
+  },
+  "constraints": {
+    "code_language": "English",
+    "chat_language": "German",
+    "delivery_model": "Feature branches -> PR CI -> merge to master -> release",
+    "merge_strategy": "squash merge",
+    "demo_only": true,
+    "live_trading": false
+  },
+  "disclaimers": {
+    "financial": "TradeLab does not provide financial advice or investment recommendations.",
+    "ai_assistance": "The repository includes AI-assisted code and documentation."
+  },
+  "api_highlights": {
+    "public_routes": [
+      "GET /healthz",
+      "GET /api/v1/markets",
+      "GET /api/v1/markets/{symbol}/candles",
+      "POST /api/v1/sessions/demo"
+    ],
+    "protected_routes": [
+      "GET /api/v1/portfolios/{walletID}",
+      "GET /api/v1/orders",
+      "GET /api/v1/activity",
+      "POST /api/v1/orders"
+    ],
+    "auth_model": "Bearer token from demo session"
+  }
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,6 +2,8 @@
 
 TradeLab ships with a Kubernetes deployment layout under `deploy/kubernetes` and publishes ready-to-run container images to GitHub Container Registry on every successful `master` release.
 
+For the broader runtime model and operator workflow, see [system-operations.md](system-operations.md). For contributor workflow and local setup, see [developer-guide.md](developer-guide.md).
+
 ## What gets deployed
 
 - `PostgreSQL` as a `StatefulSet` with a persistent volume claim

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,0 +1,138 @@
+# Developer Guide
+
+## Purpose
+
+This guide explains how to work in the TradeLab repository safely and efficiently as a contributor.
+
+## Core references
+
+- Product intent:
+  [PRD.md](PRD.md)
+- Data model:
+  [data-model.md](data-model.md)
+- Runtime and operations:
+  [system-operations.md](system-operations.md)
+- Deployment details:
+  [deployment.md](deployment.md)
+- Machine-readable repo metadata:
+  [ai-metadata.json](ai-metadata.json)
+
+## Required tools
+
+- Go
+- Node.js and npm
+- PostgreSQL or Docker for local PostgreSQL
+- Git
+- optional but useful:
+  - `kubectl` with kustomize support
+  - GitHub CLI
+
+## Local workflow
+
+### Start dependencies
+
+```bash
+docker compose up -d postgres
+```
+
+### Run backend
+
+```bash
+cd backend
+go run ./cmd/api
+```
+
+### Run migrations
+
+```bash
+cd backend
+go run ./cmd/migrate up
+```
+
+### Run frontend
+
+```bash
+cd frontend
+npm run dev
+```
+
+## Test commands
+
+### Backend
+
+```bash
+cd backend
+go test ./...
+```
+
+### Frontend
+
+```bash
+cd frontend
+npm run test
+npm run build
+```
+
+### Optional deployment validation
+
+```bash
+kubectl kustomize deploy/kubernetes/overlays/development
+kubectl kustomize deploy/kubernetes/overlays/production
+```
+
+## Architecture map
+
+### Backend
+
+- `backend/cmd/api`: API entrypoint
+- `backend/cmd/migrate`: migration entrypoint
+- `backend/internal/domain`: domain types
+- `backend/internal/service`: business logic
+- `backend/internal/store`: repository interfaces
+- `backend/internal/store/postgres`: PostgreSQL implementations
+- `backend/internal/http`: routing and API response shaping
+
+### Frontend
+
+- `frontend/app`: app entrypoints
+- `frontend/components`: UI components, including the trading dashboard
+- `frontend/lib`: API client code and shared helpers
+- `frontend/__tests__`: component and workflow tests
+
+### Delivery and deployment
+
+- `.github/workflows`: CI, auto-merge, and release automation
+- `deploy/kubernetes`: base manifests, overlays, and release rendering helper
+
+## Contribution model
+
+TradeLab currently follows a PR-first workflow:
+
+- changes are grouped into focused branches and pull requests
+- CI must pass before merge
+- merges are expected to remain reviewable and reasonably scoped
+- `master` is the release branch
+- successful `master` runs produce release artifacts and published container images
+
+## Contribution expectations
+
+When making changes:
+
+- keep code and documentation in English
+- add or update tests when behavior changes
+- keep documentation aligned with implementation, especially API and deployment behavior
+- reference the relevant issue in the PR where possible
+- prefer updating existing docs over creating redundant parallel explanations
+
+## Documentation expectations
+
+- the root README is for repository landing-page readers
+- `docs/system-operations.md` is the runtime and operator source of truth
+- `docs/developer-guide.md` is the contributor source of truth
+- `docs/ai-metadata.json` exists for machine consumption and should be updated when the human-facing structure materially changes
+
+## Notes for future contributors
+
+- market-data behavior now includes bounded stale fallback semantics
+- release-ready Kubernetes output should use immutable release tags, not rely on `latest`
+- protected API routes depend on demo-session bearer tokens

--- a/docs/system-operations.md
+++ b/docs/system-operations.md
@@ -1,0 +1,134 @@
+# System Operations
+
+## Purpose
+
+This document explains how TradeLab is operated as a running system: which components exist, how they are configured, how releases move through the system, and what an operator should check first when something goes wrong.
+
+## Runtime topology
+
+TradeLab currently consists of these runtime components:
+
+- `frontend`: Next.js web application served as the user-facing interface
+- `backend`: Go HTTP API that owns session handling, portfolio logic, order execution, and market-data access
+- `postgres`: PostgreSQL database for persistent application state
+- `ingress`: routes `/` to the frontend and `/api` to the backend
+- `migration initContainer`: applies schema migrations before the backend starts
+- `GitHub Actions + GHCR`: build, verify, publish, and package release artifacts
+
+## Environments
+
+### Development
+
+- Kubernetes namespace: `tradelab-dev`
+- image tags: `latest`
+- database secret source: local ignored `.env.database`
+- intended for fast local or shared-dev iteration
+
+### Production
+
+- Kubernetes namespace: `tradelab`
+- image tags in release manifests: immutable release tag such as `v0.1.<run-number>`
+- database secret source: external secrets integration
+- intended for controlled deployment via packaged release manifests
+
+## Configuration and secrets
+
+### Backend
+
+Important backend configuration includes:
+
+- `HTTP_ADDRESS`
+- `DATABASE_URL`
+- `MARKET_DATA_BASE_URL`
+
+### Frontend
+
+Important frontend configuration includes:
+
+- `NEXT_PUBLIC_API_BASE_URL`
+- any same-origin or proxy alignment needed for local/runtime routing
+
+### Secrets
+
+Secret-bearing values should not be committed directly into base manifests.
+
+- development secrets come from `deploy/kubernetes/overlays/development/.env.database`
+- production secrets come from the configured external secret store
+- database credentials and `DATABASE_URL` are the primary required runtime secrets today
+
+## Deployment flow
+
+### Development deploy
+
+1. Create `deploy/kubernetes/overlays/development/.env.database`.
+2. Render or apply the development overlay.
+3. Verify ingress, backend health, and frontend availability.
+
+### Production deploy
+
+1. Ensure the external secret store is populated.
+2. Ensure the release workflow has produced immutable images and a packaged manifest artifact.
+3. Render the release manifest with `deploy/kubernetes/render-release-manifests.sh` or use the packaged release artifact.
+4. Apply the manifest.
+5. Verify backend health, frontend reachability, and database connectivity.
+
+## Release model
+
+TradeLab uses a PR-first delivery model:
+
+1. Feature work lands through pull requests.
+2. CI validates backend tests, frontend tests, frontend build, container builds, and Kubernetes rendering.
+3. A successful merge into `master` triggers the release workflow.
+4. The release workflow:
+   - verifies backend and frontend again
+   - builds release artifacts
+   - publishes GHCR images
+   - renders immutable Kubernetes release manifests
+   - creates a GitHub Release
+
+## Health and failure surfaces
+
+### First places to check
+
+- backend `/healthz` for application readiness
+- GitHub Actions logs for CI, release, or packaging failures
+- Kubernetes pod status for migration, backend, frontend, and database pods
+- ingress routing if the UI is up but API requests fail
+
+### Common failure classes
+
+- `database startup or migration failure`
+  Usually visible first in the migration initContainer or backend pod startup.
+- `secret/configuration failure`
+  Usually visible as failed pod startup, database auth errors, or unreachable upstreams.
+- `market-data upstream degradation`
+  Backend may fall back to stale market data for a bounded period; after that, market-dependent actions can fail explicitly.
+- `release packaging failure`
+  Usually visible in GitHub Actions during image publication or manifest rendering.
+
+## Rollback expectations
+
+- application rollback should be driven by reapplying a previously released immutable manifest or deploying an older release artifact
+- database rollback is not automatic and must be evaluated separately from application rollback
+- if a release introduces runtime regressions without schema incompatibility, the preferred rollback path is a prior release manifest and image set
+
+## Operator checklist
+
+Before deploy:
+
+- secret sources are available
+- release artifacts or render inputs are correct
+- ingress host values are correct for the target environment
+
+After deploy:
+
+- backend `/healthz` responds
+- frontend loads and can reach `/api`
+- database-backed routes respond successfully
+- session creation and protected API access work
+
+When triaging incidents:
+
+- identify whether the failure is build/release, deployment/runtime, or upstream market-data related
+- verify the most recent successful release and manifest tag
+- confirm whether stale market-data fallback is masking or delaying a harder upstream failure


### PR DESCRIPTION
## Summary
- rewrite the README as a user-facing landing page with AI and financial disclaimers
- add dedicated system operations and developer guides under docs/
- add a machine-readable JSON metadata export for future AI tooling

## Validation
- manually reviewed README, deployment docs, system operations doc, developer guide, and metadata dump for consistency
- parsed docs/ai-metadata.json successfully with ConvertFrom-Json
- updated API examples to match the demo-session bearer-token flow

Closes #21
Closes #22
Closes #23
Closes #24