### PR TITLE
Improve phase 1 installation and first-run guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Visual walkthrough:
 
 The full user-facing walkthrough lives in [docs/user-guide.md](docs/user-guide.md).
 
+For setup and first successful run guidance by audience, start with [docs/getting-started.md](docs/getting-started.md).
+
 ## Quality and delivery
 
 TradeLab is maintained with a product-style engineering workflow:
@@ -84,7 +86,9 @@ TradeLab is intentionally developed in the open with a curated product roadmap.
 ## Documentation index
 
 - users:
-  [docs/user-guide.md](docs/user-guide.md)
+  [docs/getting-started.md](docs/getting-started.md),
+  [docs/user-guide.md](docs/user-guide.md),
+  [docs/onboarding-requirements.md](docs/onboarding-requirements.md)
 - product and planning:
   [docs/PRD.md](docs/PRD.md),
   [docs/roadmap.md](docs/roadmap.md)
@@ -94,6 +98,7 @@ TradeLab is intentionally developed in the open with a curated product roadmap.
 - operators:
   [docs/system-operations.md](docs/system-operations.md),
   [docs/deployment.md](docs/deployment.md),
+  [docs/installation-validation.md](docs/installation-validation.md),
   [docs/release-process.md](docs/release-process.md)
 - machine-readable metadata:
   [docs/ai-metadata.json](docs/ai-metadata.json)
@@ -127,17 +132,12 @@ Only set parameters if you are deviating from the defaults:
 
 For the full parameter matrix, including Kubernetes development and production values, see [docs/deployment.md](docs/deployment.md).
 
+For the full first-run path and acceptance checklist, see [docs/getting-started.md](docs/getting-started.md) and [docs/installation-validation.md](docs/installation-validation.md).
+
 ### Start PostgreSQL
 
 ```bash
 docker compose up -d postgres
-```
-
-### Run the backend
-
-```bash
-cd backend
-go run ./cmd/api
 ```
 
 ### Apply database migrations
@@ -145,6 +145,13 @@ go run ./cmd/api
 ```bash
 cd backend
 go run ./cmd/migrate up
+```
+
+### Run the backend
+
+```bash
+cd backend
+go run ./cmd/api
 ```
 
 ### Run the frontend

--- a/docs/ai-metadata.json
+++ b/docs/ai-metadata.json
@@ -5,6 +5,7 @@
     "reference_market": "XRP/USDT",
     "status": "demo-only",
     "financial_advice": false,
+    "live_trading": false,
     "ai_assisted_repository": true,
     "github_positioning": "product-first serious startup repository"
   },
@@ -42,7 +43,10 @@
   ],
   "documentation": {
     "readme": "README.md",
+    "getting_started": "docs/getting-started.md",
     "user_guide": "docs/user-guide.md",
+    "installation_validation": "docs/installation-validation.md",
+    "onboarding_requirements": "docs/onboarding-requirements.md",
     "product": "docs/PRD.md",
     "roadmap": "docs/roadmap.md",
     "data_model": "docs/data-model.md",
@@ -62,7 +66,7 @@
     "maintenance_expectations": [
       "Keep tests aligned with behavior changes.",
       "Adjust structured logging when backend control flow changes.",
-      "Update documentation and docs/ai-metadata.json when repository structure or workflows materially change.",
+      "Update documentation and docs/ai-metadata.json when repository structure, onboarding, or workflows materially change.",
       "Update GitHub Actions when quality gates or release flow need to evolve."
     ]
   },
@@ -141,12 +145,35 @@
     ]
   },
   "user_workflows": [
-    "Open the app and create a demo session automatically.",
+    "Open the app and create a guest demo session automatically.",
     "Inspect the default XRP/USDT reference market and chart feed state.",
     "Switch intervals or markets without clearing portfolio panels.",
     "Execute a demo market buy.",
     "Review balances, positions, orders, and activity after execution."
   ],
+  "onboarding": {
+    "audiences": [
+      "developer local setup",
+      "operator deployment setup",
+      "first-time product review"
+    ],
+    "local_first_run_order": [
+      "start PostgreSQL",
+      "apply database migrations",
+      "start the backend",
+      "start the frontend",
+      "open the app and confirm guest demo session creation"
+    ],
+    "first_run_acceptance": [
+      "backend health endpoint responds",
+      "frontend renders the dashboard",
+      "a guest demo session is created automatically",
+      "markets and chart data load",
+      "portfolio panels load",
+      "a demo buy updates balances, positions, orders, and activity"
+    ],
+    "product_requirements_doc": "docs/onboarding-requirements.md"
+  },
   "documentation_assets": {
     "screenshots_directory": "docs/screenshots/",
     "screenshot_generation": "frontend/scripts/capture-doc-screenshots.mjs",
@@ -199,6 +226,312 @@
       "DATABASE_URL"
     ],
     "parameter_reference_doc": "docs/deployment.md"
+  },
+  "phase_tracking": {
+    "phase_1": {
+      "epic_issue": 30,
+      "focus": "Installation, first configuration, and first run",
+      "child_issues": [36, 37, 38, 39, 40]
+    },
+    "phase_2": {
+      "epic_issue": 31,
+      "focus": "Authentication and account model",
+      "child_issues": [41, 42, 43, 44, 45],
+      "locked_decisions": {
+        "managed_auth_provider": "Clerk",
+        "guest_mode": true,
+        "social_login_targets": ["Google", "Apple"]
+      }
+    },
+    "phase_3": {
+      "epic_issue": 32,
+      "focus": "Security posture for sessions, credentials, and secrets",
+      "child_issues": [46, 47, 48, 49, 50]
+    },
+    "phase_4": {
+      "epic_issue": 33,
+      "focus": "Core trading completion",
+      "child_issues": [51, 52, 53, 54, 55]
+    },
+    "phase_5": {
+      "epic_issue": 34,
+      "focus": "Strategy automation v1",
+      "child_issues": [56, 57, 58, 59, 60]
+    },
+    "phase_6": {
+      "epic_issue": 35,
+      "focus": "Backtesting v1",
+      "child_issues": [61, 62, 63, 64]
+    }
+  },
+  "artifact_groups": {
+    "public_docs": [
+      "README.md",
+      "docs/getting-started.md",
+      "docs/user-guide.md"
+    ],
+    "user_docs": [
+      "docs/getting-started.md",
+      "docs/user-guide.md",
+      "docs/onboarding-requirements.md"
+    ],
+    "developer_docs": [
+      "docs/developer-guide.md",
+      "docs/data-model.md",
+      "docs/ai-metadata.json"
+    ],
+    "operator_docs": [
+      "docs/deployment.md",
+      "docs/system-operations.md",
+      "docs/installation-validation.md"
+    ],
+    "planning_docs": [
+      "docs/PRD.md",
+      "docs/roadmap.md"
+    ],
+    "community_health_docs": [
+      "CONTRIBUTING.md",
+      "SECURITY.md",
+      "CODE_OF_CONDUCT.md",
+      "SUPPORT.md",
+      "CODEOWNERS"
+    ],
+    "github_templates": [
+      ".github/pull_request_template.md",
+      ".github/ISSUE_TEMPLATE/"
+    ],
+    "visual_docs": [
+      "docs/screenshots/",
+      "docs/assets/github-social-preview.svg"
+    ],
+    "frontend_tests": [
+      "frontend/__tests__/",
+      "frontend/components/"
+    ],
+    "backend_tests": [
+      "backend/internal/",
+      "backend/cmd/"
+    ],
+    "e2e_tests": [
+      "frontend/e2e/"
+    ],
+    "release_and_delivery_docs": [
+      "docs/system-operations.md",
+      "docs/release-process.md",
+      "docs/github-rollout.md"
+    ],
+    "workflow_files": [
+      ".github/workflows/"
+    ]
+  },
+  "change_management": {
+    "change_categories": [
+      "ui_visual_change",
+      "ui_user_flow_change",
+      "frontend_data_flow_change",
+      "api_surface_change",
+      "backend_behavior_change",
+      "domain_or_data_model_change",
+      "configuration_change",
+      "deployment_change",
+      "release_flow_change",
+      "github_process_change",
+      "documentation_structure_change",
+      "testing_strategy_change"
+    ],
+    "rules": {
+      "ui_visual_change": {
+        "required_followups": [
+          "review public_docs",
+          "review user_docs",
+          "review visual_docs",
+          "review frontend_tests"
+        ],
+        "conditional_followups": [
+          "refresh screenshots when visible dashboard or workflow visuals change materially"
+        ],
+        "validation_expectations": [
+          "verify screenshots still match the visible UI",
+          "verify user-guide workflow text still matches the screen"
+        ]
+      },
+      "ui_user_flow_change": {
+        "required_followups": [
+          "update docs/user-guide.md",
+          "update docs/getting-started.md",
+          "review README.md",
+          "review e2e_tests"
+        ],
+        "conditional_followups": [
+          "update docs/onboarding-requirements.md when the first-run or guest-flow behavior changes"
+        ],
+        "validation_expectations": [
+          "verify the documented user path matches the actual UI flow"
+        ]
+      },
+      "api_surface_change": {
+        "required_followups": [
+          "update README.md sample API flow if public usage changes",
+          "update backend_tests",
+          "update docs/ai-metadata.json"
+        ],
+        "conditional_followups": [
+          "update frontend_tests and e2e_tests if the frontend consumes the new or changed route",
+          "update docs/getting-started.md or docs/installation-validation.md if the first-run smoke path changes"
+        ],
+        "validation_expectations": [
+          "verify API examples and protected-route expectations remain correct"
+        ]
+      },
+      "backend_behavior_change": {
+        "required_followups": [
+          "review backend_tests",
+          "review structured logging expectations",
+          "review docs/ai-metadata.json"
+        ],
+        "conditional_followups": [
+          "update user and operator docs if visible or operational behavior changes"
+        ],
+        "validation_expectations": [
+          "verify behavior and logging remain aligned"
+        ]
+      },
+      "domain_or_data_model_change": {
+        "required_followups": [
+          "update docs/data-model.md",
+          "review backend_tests",
+          "review docs/ai-metadata.json"
+        ],
+        "conditional_followups": [
+          "update API, user, or operator docs if the model change becomes externally visible"
+        ],
+        "validation_expectations": [
+          "verify docs/data-model.md matches the persisted model"
+        ]
+      },
+      "configuration_change": {
+        "required_followups": [
+          "update README.md",
+          "update docs/getting-started.md",
+          "update docs/deployment.md",
+          "update docs/developer-guide.md",
+          "update docs/installation-validation.md",
+          "update docs/ai-metadata.json"
+        ],
+        "conditional_followups": [
+          "update docs/system-operations.md when runtime responsibilities or operator checks change"
+        ],
+        "validation_expectations": [
+          "verify required versus optional parameters are still documented correctly"
+        ]
+      },
+      "deployment_change": {
+        "required_followups": [
+          "update docs/deployment.md",
+          "update docs/system-operations.md",
+          "review workflow_files",
+          "update docs/ai-metadata.json"
+        ],
+        "conditional_followups": [
+          "update docs/installation-validation.md when smoke validation changes",
+          "update README.md when the public delivery story changes"
+        ],
+        "validation_expectations": [
+          "verify deployment instructions still match manifests and release behavior"
+        ]
+      },
+      "release_flow_change": {
+        "required_followups": [
+          "update README.md",
+          "update docs/system-operations.md",
+          "review workflow_files",
+          "update docs/ai-metadata.json"
+        ],
+        "conditional_followups": [
+          "update docs/getting-started.md or docs/developer-guide.md when contributor steps change"
+        ],
+        "validation_expectations": [
+          "verify PR -> CI -> merge -> release documentation remains accurate"
+        ]
+      },
+      "github_process_change": {
+        "required_followups": [
+          "review community_health_docs",
+          "review github_templates",
+          "update docs/github-rollout.md",
+          "update docs/ai-metadata.json"
+        ],
+        "conditional_followups": [
+          "update README.md or docs/developer-guide.md if public contribution expectations change"
+        ],
+        "validation_expectations": [
+          "verify public repository standards still match GitHub configuration"
+        ]
+      },
+      "documentation_structure_change": {
+        "required_followups": [
+          "update README.md doc index and links",
+          "update docs/ai-metadata.json"
+        ],
+        "conditional_followups": [
+          "update other docs that link to moved or new sources of truth"
+        ],
+        "validation_expectations": [
+          "verify all documentation links resolve"
+        ]
+      },
+      "testing_strategy_change": {
+        "required_followups": [
+          "update docs/developer-guide.md",
+          "review workflow_files",
+          "update docs/ai-metadata.json"
+        ],
+        "conditional_followups": [
+          "update README.md when public quality gates or trust signals change"
+        ],
+        "validation_expectations": [
+          "verify documented quality gates match CI"
+        ]
+      }
+    },
+    "examples": [
+      {
+        "scenario": "Change the dashboard layout",
+        "followups": [
+          "review screenshots",
+          "update docs/user-guide.md",
+          "review README.md workflow description",
+          "review frontend tests"
+        ]
+      },
+      {
+        "scenario": "Add a new API endpoint",
+        "followups": [
+          "update API examples or public docs if relevant",
+          "update backend tests",
+          "update frontend tests if consumed",
+          "update docs/ai-metadata.json"
+        ]
+      },
+      {
+        "scenario": "Change first-run setup or required environment variables",
+        "followups": [
+          "update docs/getting-started.md",
+          "update docs/deployment.md",
+          "update docs/installation-validation.md",
+          "update README.md",
+          "update docs/ai-metadata.json"
+        ]
+      },
+      {
+        "scenario": "Add a new GitHub template or process",
+        "followups": [
+          "update docs/github-rollout.md",
+          "update docs/developer-guide.md",
+          "update docs/ai-metadata.json"
+        ]
+      }
+    ]
   },
   "github_rollout": {
     "manual_settings_doc": "docs/github-rollout.md",

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,7 +2,7 @@
 
 TradeLab ships with a Kubernetes deployment layout under `deploy/kubernetes` and publishes ready-to-run container images to GitHub Container Registry on every successful `master` release.
 
-For the broader runtime model and operator workflow, see [system-operations.md](system-operations.md). For contributor workflow and local setup, see [developer-guide.md](developer-guide.md).
+For the broader runtime model and operator workflow, see [system-operations.md](system-operations.md). For contributor workflow and local setup, see [developer-guide.md](developer-guide.md). For a first successful run by audience, start with [getting-started.md](getting-started.md).
 
 ## What gets deployed
 
@@ -38,6 +38,14 @@ manifest artifact or render production manifests through the release helper scri
 - `kubectl` with `kustomize` support
 - access to the published `ghcr.io/aidun/*` images
 
+## Audience-specific use
+
+Use this document differently depending on your role:
+
+- developers should use it as the parameter reference after reading [getting-started.md](getting-started.md)
+- operators should use it as the deployment execution guide together with [system-operations.md](system-operations.md)
+- first-time product reviewers usually do not need this document and should start with [user-guide.md](user-guide.md)
+
 ## Parameter reference
 
 This section explains which parameters exist, when they need to be set, and where they are consumed.
@@ -66,6 +74,13 @@ Recommended local default:
 - leave `NEXT_PUBLIC_API_BASE_URL` unset
 - leave `TRADESLAB_API_PROXY_TARGET` unset if the backend runs on `http://localhost:8080`
 - only set `DATABASE_URL` if your local PostgreSQL credentials or host differ from the default
+
+First local run order:
+
+1. start PostgreSQL
+2. apply migrations
+3. start the backend
+4. start the frontend
 
 ### Kubernetes development parameters
 
@@ -148,6 +163,14 @@ Then apply it:
 kubectl apply -k deploy/kubernetes/overlays/development
 ```
 
+After apply, validate:
+
+- PostgreSQL pod is healthy
+- migration init container completed
+- backend `/healthz` responds
+- frontend loads through ingress
+- a guest demo session can be created
+
 If you are testing locally with an ingress controller, map `tradelab.localtest.me` to your cluster ingress IP or use a wildcard resolver such as `localtest.me`.
 
 ## Production deployment
@@ -176,9 +199,12 @@ For immutable production output tied to a release tag, render the packaged manif
 kubectl apply -f /tmp/tradelab-kubernetes.yaml
 ```
 
+After apply, validate the first protected product flow with [installation-validation.md](installation-validation.md).
+
 ## Operational notes
 
 - The backend waits on database connectivity implicitly through the migration init container.
 - Frontend requests can stay same-origin because the ingress sends `/api` traffic to the backend service.
 - The frontend also includes a rewrite fallback to `TRADESLAB_API_PROXY_TARGET`, which keeps local standalone runs aligned with the Kubernetes topology.
 - If you deploy outside the included ingress setup, re-check both `TRADESLAB_API_PROXY_TARGET` and `NEXT_PUBLIC_API_BASE_URL` so frontend requests still resolve correctly.
+- First-time install and smoke-test expectations live in [getting-started.md](getting-started.md) and [installation-validation.md](installation-validation.md).

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -20,6 +20,10 @@ This guide explains how to work in the TradeLab repository safely and efficientl
   [release-process.md](release-process.md)
 - GitHub rollout:
   [github-rollout.md](github-rollout.md)
+- First run and onboarding:
+  [getting-started.md](getting-started.md)
+- Installation validation:
+  [installation-validation.md](installation-validation.md)
 - Machine-readable repo metadata:
   [ai-metadata.json](ai-metadata.json)
 
@@ -35,7 +39,7 @@ This guide explains how to work in the TradeLab repository safely and efficientl
 
 ## Local workflow
 
-## Configuration checkpoints
+### Configuration checkpoints
 
 Before starting local services, review these only if you are not using the defaults:
 
@@ -53,18 +57,18 @@ The full environment and deployment parameter reference lives in [deployment.md]
 docker compose up -d postgres
 ```
 
-### Run backend
-
-```bash
-cd backend
-go run ./cmd/api
-```
-
 ### Run migrations
 
 ```bash
 cd backend
 go run ./cmd/migrate up
+```
+
+### Run backend
+
+```bash
+cd backend
+go run ./cmd/api
 ```
 
 ### Run frontend
@@ -189,13 +193,16 @@ When making changes:
 ## Documentation expectations
 
 - the root README is for repository landing-page readers
+- `docs/getting-started.md` is the audience-aware entrypoint for setup and first-run success
+- `docs/installation-validation.md` defines the required smoke path for local and deployed environments
+- `docs/onboarding-requirements.md` captures the intended guest-first product onboarding behavior
 - `docs/system-operations.md` is the runtime and operator source of truth
 - `docs/developer-guide.md` is the contributor source of truth
 - `docs/user-guide.md` is the user-facing walkthrough with screenshots
 - `docs/roadmap.md` is the public product direction summary
 - `docs/release-process.md` describes release artifacts and workflow meaning
 - `docs/github-rollout.md` captures manual GitHub repository settings and presentation steps
-- `docs/ai-metadata.json` exists for machine consumption and should be updated when the human-facing structure materially changes
+- `docs/ai-metadata.json` exists for machine consumption, acts as the dependency map for repo-facing follow-up work, and should be updated when the human-facing structure materially changes
 - logging, tests, documentation, and GitHub Actions are treated as part of the feature surface and should be adjusted together when needed
 
 ## AI metadata contract

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,151 @@
+# Getting Started
+
+## Purpose
+
+This guide explains how to get TradeLab running for three different audiences:
+
+- developers running the product locally
+- operators validating a deployment target
+- first-time product reviewers opening the app for the first time
+
+TradeLab is currently a demo-only trading sandbox. The first-run experience should always make that clear.
+
+## Choose your path
+
+### Local developer setup
+
+Use this path when you want to run the full stack on your machine and work on code.
+
+You will typically need:
+
+- Docker or a local PostgreSQL instance
+- Go
+- Node.js and npm
+
+Follow this order:
+
+1. start PostgreSQL
+2. apply database migrations
+3. start the backend
+4. start the frontend
+5. open the app and confirm that a demo session is created
+
+The detailed local parameter reference lives in [deployment.md](deployment.md).
+
+### Operator deployment setup
+
+Use this path when you want to validate or run TradeLab in Kubernetes.
+
+You will typically need:
+
+- a Kubernetes cluster
+- `kubectl` with kustomize support
+- ingress support
+- access to GHCR images
+- the required secret values for the chosen environment
+
+Follow this order:
+
+1. prepare environment-specific secrets and hosts
+2. render or apply the Kubernetes overlay
+3. verify backend health, frontend reachability, and session creation
+4. confirm the first protected API flow works
+
+The deployment-specific steps live in [deployment.md](deployment.md), and the runtime model lives in [system-operations.md](system-operations.md).
+
+### First-time product review
+
+Use this path when you are evaluating the product rather than modifying or operating it.
+
+What you should expect on first launch:
+
+1. the app loads the dashboard
+2. a guest demo session is created automatically
+3. the market list appears with `XRP/USDT` as the reference pair
+4. the chart loads with a feed freshness indicator
+5. portfolio panels, recent orders, and activity become visible
+
+The full walkthrough is in [user-guide.md](user-guide.md).
+
+## First local run
+
+### Step 1. Start PostgreSQL
+
+```bash
+docker compose up -d postgres
+```
+
+### Step 2. Apply migrations
+
+```bash
+cd backend
+go run ./cmd/migrate up
+```
+
+### Step 3. Start the backend
+
+```bash
+cd backend
+go run ./cmd/api
+```
+
+### Step 4. Start the frontend
+
+```bash
+cd frontend
+npm run dev
+```
+
+### Step 5. Open the app
+
+Open `http://localhost:3000` and confirm the dashboard loads.
+
+On a successful first run:
+
+- the frontend loads without a blank error screen
+- a demo session is created automatically
+- markets are visible
+- the chart renders candles
+- the wallet panels load
+
+## Configuration decisions before first run
+
+Most local runs can use the defaults.
+
+Only set configuration values when you intentionally deviate from the default topology:
+
+| Parameter | When to set it | Typical reason |
+| --- | --- | --- |
+| `DATABASE_URL` | before migrations or backend startup | your PostgreSQL host, port, user, password, or DB name differs |
+| `HTTP_ADDRESS` | before backend startup | you want the API on another address or port |
+| `MARKET_DATA_BASE_URL` | before backend startup | you want another upstream market-data base URL |
+| `TRADESLAB_API_PROXY_TARGET` | before frontend startup | the frontend should proxy `/api` to a non-default backend origin |
+| `NEXT_PUBLIC_API_BASE_URL` | before frontend startup | the browser should call a different API origin directly |
+
+For the complete matrix, see [deployment.md](deployment.md).
+
+## First-run acceptance checklist
+
+Use this checklist after setup:
+
+- PostgreSQL is reachable
+- migrations complete successfully
+- backend responds at `/healthz`
+- frontend renders the dashboard
+- a demo session is created automatically
+- the market list loads
+- the chart loads candle data
+- portfolio panels load successfully
+- a demo buy can be submitted and reflected in the dashboard
+
+The validation details for local and deployed environments live in [installation-validation.md](installation-validation.md).
+
+## Related documentation
+
+- [README.md](../README.md)
+- [deployment.md](deployment.md)
+- [developer-guide.md](developer-guide.md)
+- [system-operations.md](system-operations.md)
+- [user-guide.md](user-guide.md)
+- [installation-validation.md](installation-validation.md)
+- [onboarding-requirements.md](onboarding-requirements.md)

--- a/docs/installation-validation.md
+++ b/docs/installation-validation.md
@@ -1,0 +1,121 @@
+# Installation Validation
+
+## Purpose
+
+This document defines the expected smoke-test path for a correct TradeLab installation in local and deployed environments.
+
+The goal is simple: a new engineer or operator should be able to validate a first successful run without guessing what "working" means.
+
+## Local validation
+
+### Preconditions
+
+- PostgreSQL is running
+- database migrations were applied successfully
+- backend is running
+- frontend is running
+
+### Required checks
+
+1. `GET /healthz` returns a successful response from the backend.
+2. The frontend root page loads at the expected local address.
+3. Opening the app creates a guest demo session automatically.
+4. The market list renders at least one market and shows `XRP/USDT` as the default reference pair.
+5. The chart renders candle data for the selected market.
+6. Portfolio panels load without authentication or data errors.
+7. A demo market buy succeeds and creates visible changes in:
+   - wallet summary
+   - balances
+   - positions
+   - recent orders
+   - activity
+
+### Local validation commands
+
+Backend health:
+
+```bash
+curl http://localhost:8080/healthz
+```
+
+Manual demo session creation:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/sessions/demo
+```
+
+Protected portfolio access with the returned token:
+
+```bash
+curl http://localhost:8080/api/v1/portfolios/<wallet-id> \
+  -H "Authorization: Bearer <demo-token>"
+```
+
+Demo buy:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/orders \
+  -H "Authorization: Bearer <demo-token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "market_symbol": "XRP/USDT",
+    "quote_amount": 50
+  }'
+```
+
+### Local success criteria
+
+The installation is considered valid when:
+
+- backend health is green
+- frontend loads the dashboard
+- session creation works automatically or manually
+- protected API access succeeds with the session token
+- a demo buy updates the visible dashboard state
+
+## Deployment validation
+
+### Preconditions
+
+- Kubernetes manifests were applied successfully
+- required secrets are present for the target environment
+- ingress host routing is configured correctly
+
+### Required checks
+
+1. Backend pods are healthy.
+2. Frontend pods are healthy.
+3. PostgreSQL is healthy and reachable from the backend.
+4. Migration init container completed successfully.
+5. The public frontend loads.
+6. The frontend can reach `/api`.
+7. A guest demo session is created automatically in the browser.
+8. Protected portfolio routes succeed after session creation.
+9. A demo buy succeeds and updates the user-facing dashboard state.
+
+### Deployment success criteria
+
+The deployment is considered valid when:
+
+- all runtime components are healthy
+- the first protected product flow works end-to-end
+- no configuration, secret, or ingress mismatch blocks the demo experience
+
+## Failure classification
+
+Use this quick classification when validation fails:
+
+| Symptom | First place to check |
+| --- | --- |
+| backend health fails | backend logs, pod status, database connectivity |
+| frontend loads but `/api` fails | ingress routing, frontend proxy config, backend service |
+| demo session fails | backend logs, database migrations, session tables |
+| chart fails | backend market-data logs, upstream reachability, stale fallback state |
+| portfolio or orders fail | auth headers, session validity, backend logs, database state |
+
+## Related documentation
+
+- [getting-started.md](getting-started.md)
+- [deployment.md](deployment.md)
+- [system-operations.md](system-operations.md)
+- [user-guide.md](user-guide.md)

--- a/docs/onboarding-requirements.md
+++ b/docs/onboarding-requirements.md
@@ -1,0 +1,75 @@
+# Onboarding Requirements
+
+## Purpose
+
+This document defines what the first-launch user experience must communicate and validate while TradeLab remains a guest-first, demo-only product.
+
+## Product stance on first launch
+
+The first launch must make these points understandable without requiring a user to read the repository:
+
+- TradeLab is a demo trading sandbox
+- the initial experience uses a guest demo session
+- no live money, brokerage account, or custody relationship is involved
+- market data can be fresh or temporarily stale, and the UI should communicate that clearly
+
+## First-launch UX requirements
+
+### Session creation
+
+On first load, the frontend should:
+
+1. create a guest demo session automatically
+2. avoid making the user hunt for a signup flow before trying the product
+3. surface an actionable error if session creation fails
+
+### Demo-mode explanation
+
+The UI should communicate, in visible product language, that:
+
+- the session is a guest demo session
+- balances are virtual
+- trading actions are simulated
+
+### Initial dashboard state
+
+Once session bootstrap succeeds, the initial dashboard should make these surfaces visible:
+
+- selected reference market
+- chart and feed status
+- wallet summary
+- balances
+- recent orders
+- activity
+
+### Failure handling
+
+If first-run steps fail, the UI should prefer:
+
+- specific error language over generic failure states
+- isolated loading and error states where possible
+- recovery actions such as refresh or retry guidance
+
+## Onboarding acceptance criteria
+
+The onboarding UX is acceptable when:
+
+- a first-time user understands they are in demo mode
+- a first-time user does not need credentials to try the product
+- the default market and chart state are understandable
+- the first successful session-to-dashboard path is obvious
+- failure states do not hide the reason or the next action
+
+## Future compatibility
+
+These requirements should continue to hold when registered accounts are introduced:
+
+- guest mode remains a low-friction entry point
+- registered mode becomes the durable path without replacing the demo-first experience
+- the distinction between guest demo sessions and registered accounts stays explicit
+
+## Related documentation
+
+- [getting-started.md](getting-started.md)
+- [user-guide.md](user-guide.md)
+- [PRD.md](PRD.md)

--- a/docs/system-operations.md
+++ b/docs/system-operations.md
@@ -4,6 +4,8 @@
 
 This document explains how TradeLab is operated as a running system: which components exist, how they are configured, how releases move through the system, and what an operator should check first when something goes wrong.
 
+For audience-specific first setup and smoke validation, see [getting-started.md](getting-started.md) and [installation-validation.md](installation-validation.md).
+
 ## Runtime topology
 
 TradeLab currently consists of these runtime components:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -114,8 +114,12 @@ The current product is still intentionally narrow:
 
 - Repository overview:
   [README.md](../README.md)
+- Getting started:
+  [getting-started.md](getting-started.md)
 - Product intent:
   [PRD.md](PRD.md)
+- First-launch behavior:
+  [onboarding-requirements.md](onboarding-requirements.md)
 - Runtime and operations:
   [system-operations.md](system-operations.md)
 - Developer onboarding:


### PR DESCRIPTION
## Summary
- add an audience-aware getting started guide for developers, operators, and first-time product reviewers
- define first-run validation and onboarding expectations for the current guest-first demo experience
- update README, deployment, developer, user, system, and AI metadata docs to keep Phase 1 onboarding coherent

## Validation
- parsed docs/ai-metadata.json successfully with ConvertFrom-Json
- verified the new onboarding and validation documentation paths exist

Closes #36
Closes #37
Closes #38
Closes #39
Closes #40