### PR TITLE
Define phase 2 authentication model and Clerk roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ TradeLab is intentionally developed in the open with a curated product roadmap.
   [docs/onboarding-requirements.md](docs/onboarding-requirements.md)
 - product and planning:
   [docs/PRD.md](docs/PRD.md),
+  [docs/authentication-model.md](docs/authentication-model.md),
   [docs/roadmap.md](docs/roadmap.md)
 - developers:
   [docs/developer-guide.md](docs/developer-guide.md),
@@ -113,6 +114,15 @@ TradeLab is intentionally developed in the open with a curated product roadmap.
   [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
 - support guidance:
   [SUPPORT.md](SUPPORT.md)
+
+## Identity roadmap
+
+TradeLab currently uses guest demo sessions for the low-friction first run. The next identity phase is defined around Clerk-backed registered accounts with Google and Apple sign-in, while keeping guest mode as the entry path.
+
+- [docs/authentication-model.md](docs/authentication-model.md)
+- [docs/clerk-architecture.md](docs/clerk-architecture.md)
+- [docs/auth-flows.md](docs/auth-flows.md)
+- [docs/account-lifecycle.md](docs/account-lifecycle.md)
 
 ## Local development
 

--- a/docs/account-lifecycle.md
+++ b/docs/account-lifecycle.md
@@ -1,0 +1,88 @@
+# Account Lifecycle
+
+## Purpose
+
+This document defines how guest sessions and registered accounts should behave over time in TradeLab.
+
+## Lifecycle types
+
+TradeLab should support two lifecycle types:
+
+- guest lifecycle
+- registered account lifecycle
+
+## Guest lifecycle
+
+### Creation
+
+- created automatically on first launch
+- attached to a temporary demo wallet
+
+### Active use
+
+- user can inspect markets and place demo trades
+- state is temporary and should not be treated as durable ownership
+
+### Expiry
+
+- guest sessions should expire automatically after their time window
+- expired guest sessions should not pretend to preserve long-term continuity
+
+### Upgrade
+
+Guest users should be able to upgrade to a registered account.
+
+The upgrade path should define whether:
+
+- demo balances are preserved
+- trade history is preserved
+- a new durable account is created and linked
+
+The product should explicitly communicate the chosen behavior.
+
+## Registered account lifecycle
+
+### Creation
+
+- created through Clerk signup or first successful social login
+- mapped to an internal TradeLab user record
+
+### Active use
+
+- supports repeat access across sessions and devices
+- owns durable demo-account state
+
+### Session loss or expiry
+
+- identity re-authentication happens through Clerk
+- durable product data remains attached to the registered account
+
+### Logout
+
+- user leaves the durable account context
+- the product should either return to a signed-out state or offer guest re-entry
+
+## Multi-device expectations
+
+Registered accounts should support multi-device continuity.
+
+This means:
+
+- the same user should regain the same durable demo state after login
+- device switching should not fork identity unintentionally
+
+## Retention and cleanup expectations
+
+TradeLab should eventually define:
+
+- guest-session cleanup rules
+- registered-account retention expectations
+- how long expired guest data is kept, if at all
+
+These retention rules should later align with the Phase 3 security and sensitive-data handling work.
+
+## Related documentation
+
+- [authentication-model.md](authentication-model.md)
+- [auth-flows.md](auth-flows.md)
+- [clerk-architecture.md](clerk-architecture.md)

--- a/docs/ai-metadata.json
+++ b/docs/ai-metadata.json
@@ -47,6 +47,10 @@
     "user_guide": "docs/user-guide.md",
     "installation_validation": "docs/installation-validation.md",
     "onboarding_requirements": "docs/onboarding-requirements.md",
+    "authentication_model": "docs/authentication-model.md",
+    "clerk_architecture": "docs/clerk-architecture.md",
+    "auth_flows": "docs/auth-flows.md",
+    "account_lifecycle": "docs/account-lifecycle.md",
     "product": "docs/PRD.md",
     "roadmap": "docs/roadmap.md",
     "data_model": "docs/data-model.md",
@@ -87,7 +91,7 @@
       "GET /api/v1/activity",
       "POST /api/v1/orders"
     ],
-    "auth_model": "Bearer token from demo session"
+    "auth_model": "Bearer token from demo session today, planned transition to Clerk-backed registered accounts plus TradeLab application sessions"
   },
   "quality_gates": {
     "ci_jobs": [
@@ -173,6 +177,18 @@
       "a demo buy updates balances, positions, orders, and activity"
     ],
     "product_requirements_doc": "docs/onboarding-requirements.md"
+  },
+  "identity_roadmap": {
+    "current_state": "guest demo sessions only",
+    "target_state": "guest mode plus Clerk-backed registered accounts",
+    "managed_auth_provider": "Clerk",
+    "social_login_targets": ["Google", "Apple"],
+    "documentation": [
+      "docs/authentication-model.md",
+      "docs/clerk-architecture.md",
+      "docs/auth-flows.md",
+      "docs/account-lifecycle.md"
+    ]
   },
   "documentation_assets": {
     "screenshots_directory": "docs/screenshots/",
@@ -273,12 +289,16 @@
     "user_docs": [
       "docs/getting-started.md",
       "docs/user-guide.md",
-      "docs/onboarding-requirements.md"
+      "docs/onboarding-requirements.md",
+      "docs/auth-flows.md"
     ],
     "developer_docs": [
       "docs/developer-guide.md",
       "docs/data-model.md",
-      "docs/ai-metadata.json"
+      "docs/ai-metadata.json",
+      "docs/authentication-model.md",
+      "docs/clerk-architecture.md",
+      "docs/account-lifecycle.md"
     ],
     "operator_docs": [
       "docs/deployment.md",
@@ -330,6 +350,7 @@
       "ui_user_flow_change",
       "frontend_data_flow_change",
       "api_surface_change",
+      "identity_or_auth_change",
       "backend_behavior_change",
       "domain_or_data_model_change",
       "configuration_change",
@@ -381,6 +402,23 @@
         ],
         "validation_expectations": [
           "verify API examples and protected-route expectations remain correct"
+        ]
+      },
+      "identity_or_auth_change": {
+        "required_followups": [
+          "update docs/authentication-model.md",
+          "update docs/clerk-architecture.md",
+          "update docs/auth-flows.md",
+          "update docs/account-lifecycle.md",
+          "update docs/ai-metadata.json"
+        ],
+        "conditional_followups": [
+          "update README.md and docs/getting-started.md if first-run identity behavior changes",
+          "update docs/system-operations.md if trust boundaries or runtime responsibilities change",
+          "update frontend_tests, backend_tests, and e2e_tests when implementation changes land"
+        ],
+        "validation_expectations": [
+          "verify guest versus registered behavior is still documented consistently"
         ]
       },
       "backend_behavior_change": {
@@ -529,6 +567,15 @@
           "update docs/github-rollout.md",
           "update docs/developer-guide.md",
           "update docs/ai-metadata.json"
+        ]
+      },
+      {
+        "scenario": "Change the authentication model or social login providers",
+        "followups": [
+          "update auth planning docs",
+          "update README identity roadmap section",
+          "update docs/ai-metadata.json",
+          "review onboarding and operator docs for trust-boundary changes"
         ]
       }
     ]

--- a/docs/auth-flows.md
+++ b/docs/auth-flows.md
@@ -1,0 +1,96 @@
+# Authentication Flows
+
+## Purpose
+
+This document defines the intended signup, login, logout, session-expiry, and social-login flows for TradeLab.
+
+## Supported modes
+
+- guest demo session
+- registered account via Clerk
+- social login providers:
+  - Google
+  - Apple
+
+## Flow 1. Guest first launch
+
+1. User opens the app.
+2. TradeLab creates a guest demo session automatically.
+3. The dashboard loads with demo-only messaging.
+4. The user can explore markets and place demo trades without registration.
+
+Goal:
+
+- reduce first-use friction
+- let users understand the product before committing to signup
+
+## Flow 2. Sign up
+
+1. User chooses to create a durable account.
+2. Clerk presents available signup methods.
+3. User signs up with Google, Apple, or another enabled provider.
+4. TradeLab creates or links the internal user record.
+5. TradeLab initializes the durable demo account context.
+
+Goal:
+
+- convert a guest or new user into a durable product account
+
+## Flow 3. Login
+
+1. User returns to TradeLab.
+2. Clerk authenticates the user.
+3. The backend resolves the internal user and account context.
+4. The product opens into the user-owned demo environment.
+
+Goal:
+
+- restore durable access across sessions and devices
+
+## Flow 4. Logout
+
+1. User signs out from the account controls.
+2. Clerk session is terminated in the frontend.
+3. Any active registered-account application context is cleared.
+4. The product may offer a return to guest mode.
+
+Goal:
+
+- make account exit explicit and predictable
+
+## Flow 5. Session expiry
+
+TradeLab should distinguish:
+
+- guest demo-session expiry
+- registered identity/session expiry
+
+Expected behavior:
+
+- expired guest sessions prompt the user to refresh into a new guest session or sign up
+- expired registered sessions prompt re-authentication through Clerk
+- the UI should never fail silently when auth state is no longer valid
+
+## Social login requirements
+
+Google and Apple are the primary provider targets.
+
+The UX should:
+
+- show clearly which providers are supported
+- keep the provider surface compact and trustworthy
+- allow future provider additions without redesigning the auth boundary
+
+## UX requirements
+
+The auth surface should communicate:
+
+- guest mode is temporary
+- registered mode is durable
+- the product remains demo-only in both cases
+
+## Related documentation
+
+- [authentication-model.md](authentication-model.md)
+- [clerk-architecture.md](clerk-architecture.md)
+- [account-lifecycle.md](account-lifecycle.md)

--- a/docs/authentication-model.md
+++ b/docs/authentication-model.md
@@ -1,0 +1,120 @@
+# Authentication Model
+
+## Purpose
+
+This document defines the TradeLab identity model for the transition from guest demo sessions to durable registered accounts.
+
+The current product remains demo-only, but authentication is now a first-class product surface. The target identity provider is `Clerk`, with guest mode kept as the low-friction entry point.
+
+## Identity modes
+
+TradeLab should support two identity modes:
+
+### 1. Guest demo mode
+
+Guest mode is the default first-run experience.
+
+Characteristics:
+
+- starts without signup friction
+- creates a temporary demo session and demo wallet
+- uses virtual balances only
+- is intended for first exploration and product evaluation
+- does not imply durable ownership across devices unless explicitly upgraded
+
+### 2. Registered demo account
+
+Registered accounts are the durable mainline path.
+
+Characteristics:
+
+- backed by Clerk identity
+- support repeat access across sessions and devices
+- keep the product demo-only while introducing durable ownership
+- become the long-term home for user portfolio state, preferences, and later strategy settings
+
+## Locked decisions
+
+- managed auth provider: `Clerk`
+- guest mode stays
+- primary social login targets:
+  - Google
+  - Apple
+- provider model should remain extensible for future additions
+
+## Why Clerk
+
+Clerk is the planned auth provider because it supports:
+
+- fast integration with Next.js
+- managed session handling
+- social login providers
+- future support for account lifecycle features without building auth from scratch
+
+TradeLab should avoid implementing bespoke password auth in the MVP when the product still needs to mature its core trading and simulation flows.
+
+## Product behavior
+
+### First launch
+
+On first launch, TradeLab should continue to:
+
+1. open directly into the product
+2. create a guest demo session automatically
+3. explain that the user is in a demo-only sandbox
+
+### Upgrade path
+
+At the appropriate point in the user journey, the product should offer an upgrade path from guest mode to a registered account.
+
+The guest-upgrade path should:
+
+- preserve the low-friction first experience
+- make the durability benefit explicit
+- avoid forcing registration before the user understands the product
+
+## Account ownership model
+
+### Guest session ownership
+
+Guest sessions own:
+
+- a temporary demo wallet
+- temporary portfolio state
+- temporary order and activity history
+
+Guest sessions should be treated as revocable and time-bounded.
+
+### Registered account ownership
+
+Registered accounts should own:
+
+- durable user identity
+- one primary demo account at minimum
+- durable portfolio, order, position, and activity history
+- future strategy configuration and backtesting history
+
+## Session model
+
+TradeLab should separate:
+
+- `identity`: handled by Clerk
+- `application demo session`: handled by the TradeLab backend
+
+This means a registered user can still have an application-level demo session, but that session is linked to a durable identity instead of existing only as an anonymous guest token.
+
+## Future compatibility
+
+This model should support:
+
+- guest sessions
+- guest-to-registered upgrades
+- durable registered accounts
+- future multi-account or team features without replacing the core identity boundary
+
+## Related documentation
+
+- [clerk-architecture.md](clerk-architecture.md)
+- [auth-flows.md](auth-flows.md)
+- [account-lifecycle.md](account-lifecycle.md)
+- [onboarding-requirements.md](onboarding-requirements.md)

--- a/docs/clerk-architecture.md
+++ b/docs/clerk-architecture.md
@@ -1,0 +1,110 @@
+# Clerk Architecture
+
+## Purpose
+
+This document defines how Clerk should integrate with the TradeLab frontend and backend without breaking the current guest-first demo flow.
+
+## Boundary model
+
+TradeLab should use two layers:
+
+1. `Clerk identity layer`
+2. `TradeLab application session layer`
+
+Clerk is responsible for authenticating a user. The TradeLab backend remains responsible for mapping that identity to demo accounts, wallets, and trading-specific application state.
+
+## Frontend responsibilities
+
+The Next.js frontend should:
+
+- render Clerk UI for signup, login, account, and logout flows
+- distinguish clearly between guest mode and registered mode
+- attach identity context when calling registered-account backend flows
+- continue to support the current guest bootstrap path for first-time use
+
+## Backend responsibilities
+
+The Go backend should:
+
+- trust only verified Clerk identity data
+- map Clerk user IDs to internal TradeLab users
+- create and manage application demo sessions for registered users
+- keep authorization logic server-side
+- avoid trusting raw client claims for wallet ownership or account identity
+
+## Trust model
+
+The backend should not treat the frontend as the source of truth for identity.
+
+Instead:
+
+- Clerk verifies the user at the edge or frontend boundary
+- the backend verifies the authenticated identity context for protected registered-account routes
+- TradeLab maps that identity to internal state such as user IDs, wallets, and portfolios
+
+## Guest mode coexistence
+
+Guest mode should remain separate from the Clerk-backed path.
+
+This implies:
+
+- guest session creation remains available
+- guest sessions are treated as temporary and low-trust
+- registered mode uses verified external identity and durable internal ownership
+
+## Route model
+
+The future route model should distinguish:
+
+- public routes
+- guest demo routes
+- registered-account routes
+
+Examples:
+
+- public:
+  - health
+  - market list
+  - market candles
+- guest:
+  - demo session bootstrap
+  - guest portfolio access
+  - guest demo orders
+- registered:
+  - account bootstrap
+  - durable portfolio access
+  - account-bound trading history
+  - future strategies and backtests
+
+## Internal mapping
+
+TradeLab should maintain an internal user record even for Clerk-backed users.
+
+The internal model should allow:
+
+- one Clerk identity to map to one TradeLab user
+- one TradeLab user to own wallets, orders, positions, and activity
+- future expansion without coupling product data tightly to Clerk primitives
+
+## Session verification model
+
+The current bearer-token demo-session model is sufficient for guest mode, but the registered path should move toward:
+
+- verified Clerk identity
+- backend-issued or backend-resolved application session context
+- server-side authorization checks for wallet and account access
+
+## Implementation notes
+
+When this architecture is implemented:
+
+- frontend auth libraries and middleware must be added
+- backend user resolution and account mapping must be introduced
+- the API surface must distinguish guest and registered flows explicitly
+- logging and security rules must be reviewed so identity values are useful but not sensitive
+
+## Related documentation
+
+- [authentication-model.md](authentication-model.md)
+- [auth-flows.md](auth-flows.md)
+- [account-lifecycle.md](account-lifecycle.md)

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -10,6 +10,8 @@ This guide explains how to work in the TradeLab repository safely and efficientl
   [PRD.md](PRD.md)
 - Public roadmap:
   [roadmap.md](roadmap.md)
+- Authentication model:
+  [authentication-model.md](authentication-model.md)
 - Data model:
   [data-model.md](data-model.md)
 - Runtime and operations:
@@ -196,6 +198,7 @@ When making changes:
 - `docs/getting-started.md` is the audience-aware entrypoint for setup and first-run success
 - `docs/installation-validation.md` defines the required smoke path for local and deployed environments
 - `docs/onboarding-requirements.md` captures the intended guest-first product onboarding behavior
+- `docs/authentication-model.md`, `docs/clerk-architecture.md`, `docs/auth-flows.md`, and `docs/account-lifecycle.md` define the planned identity surface
 - `docs/system-operations.md` is the runtime and operator source of truth
 - `docs/developer-guide.md` is the contributor source of truth
 - `docs/user-guide.md` is the user-facing walkthrough with screenshots

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -42,10 +42,20 @@ Focus:
 - stronger visual polish
 - more usable onboarding and documentation
 
+### 5. Identity and trust
+
+Focus:
+
+- move from guest-only access to a dual model of guest sessions plus durable registered accounts
+- introduce Clerk as the managed auth provider
+- support Google and Apple sign-in
+- define account lifecycle, session behavior, and upgrade paths before live-like expansion
+
 ## Near-term priorities
 
 - keep the trading sandbox stable and understandable
 - improve public product and engineering documentation
+- define the authentication and account roadmap before implementing registered access
 - strengthen roadmap, release, and GitHub contribution signals
 - continue increasing quality gates around CI, E2E coverage, and release automation
 

--- a/docs/system-operations.md
+++ b/docs/system-operations.md
@@ -43,6 +43,8 @@ Important backend configuration includes:
 - `DATABASE_URL`
 - `MARKET_DATA_BASE_URL`
 
+Future identity changes should treat external authentication as a separate trust boundary from application trading sessions. See [authentication-model.md](authentication-model.md) and [clerk-architecture.md](clerk-architecture.md).
+
 ### Frontend
 
 Important frontend configuration includes:


### PR DESCRIPTION
## Summary
- define the TradeLab identity model as guest demo mode plus Clerk-backed registered accounts
- document the Clerk integration boundary, authentication flows, and account lifecycle expectations
- update README, roadmap, system operations, developer docs, and ai metadata so the auth roadmap is part of the main product story

## Validation
- verified the new authentication planning documents exist
- parsed docs/ai-metadata.json successfully with ConvertFrom-Json

Closes #41
Closes #42
Closes #43
Closes #44
Closes #45