### PR TITLE
Implement Phase 3 session security hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ It helps teams and individual builders:
 - demo-session based trading with isolated wallet state
 - Clerk-backed registered demo accounts with Google and Apple as the initial social-login targets
 - explicit guest-to-registered upgrade flow with preserve-versus-fresh account choice
+- HttpOnly registered app sessions plus session-scoped guest storage
 - server-authoritative market-buy execution in the Go backend
 - portfolio, balances, orders, positions, and activity history
 - market candle rendering with bounded stale-feed fallback behavior
@@ -95,7 +96,8 @@ TradeLab is intentionally developed in the open with a curated product roadmap.
 - product and planning:
   [docs/PRD.md](docs/PRD.md),
   [docs/authentication-model.md](docs/authentication-model.md),
-  [docs/roadmap.md](docs/roadmap.md)
+  [docs/roadmap.md](docs/roadmap.md),
+  [docs/security-model.md](docs/security-model.md)
 - developers:
   [docs/developer-guide.md](docs/developer-guide.md),
   [docs/data-model.md](docs/data-model.md)
@@ -147,6 +149,8 @@ Only set parameters if you are deviating from the defaults:
 | `NEXT_PUBLIC_API_BASE_URL` | before frontend startup only if the browser should call another API origin directly | empty |
 | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | before frontend startup when you want real Clerk UI instead of guest-only or mock auth mode | empty |
 | `NEXT_PUBLIC_AUTH_MOCK_MODE` | before frontend startup for local or CI auth mocking without live Clerk setup | `false` |
+
+For the current auth/session security posture and sensitive-data boundaries, see [docs/security-model.md](docs/security-model.md).
 
 For the full parameter matrix, including Kubernetes development and production values, see [docs/deployment.md](docs/deployment.md).
 

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -33,6 +33,7 @@ func main() {
 	balanceRepository := postgres.NewBalanceRepository(db)
 	portfolioRepository := postgres.NewPortfolioRepository(db)
 	sessionRepository := postgres.NewDemoSessionRepository(db)
+	appSessionRepository := postgres.NewAppSessionRepository(db)
 	registeredAccountRepository := postgres.NewRegisteredAccountRepository(db)
 
 	clerkVerifier, err := accountservice.NewClerkTokenVerifier(context.Background(), accountservice.ClerkVerifierConfig{
@@ -49,7 +50,7 @@ func main() {
 	orderService := orderservice.NewService(marketRepository, balanceRepository, portfolioRepository, marketService, logging.NewJSONLogger("order_service"))
 	portfolioService := portfolioservice.NewService(portfolioRepository, logging.NewJSONLogger("portfolio_service"))
 	historyService := historyservice.NewService(portfolioRepository, logging.NewJSONLogger("history_service"))
-	sessionService := sessionservice.NewService(sessionRepository, logging.NewJSONLogger("session_service"))
+	sessionService := sessionservice.NewService(sessionRepository, appSessionRepository, logging.NewJSONLogger("session_service"))
 	accountService := accountservice.NewService(registeredAccountRepository, clerkVerifier, logging.NewJSONLogger("account_service"))
 	server := &http.Server{
 		Addr:    cfg.HTTPAddress,

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -16,8 +16,8 @@ func Load() Config {
 		HTTPAddress:       getEnv("HTTP_ADDRESS", ":8080"),
 		DatabaseURL:       getEnv("DATABASE_URL", "postgres://tradelab:tradelab@localhost:5432/tradelab?sslmode=disable"),
 		MarketDataBaseURL: getEnv("MARKET_DATA_BASE_URL", "https://api.binance.com"),
-		ClerkIssuerURL:    getEnv("CLERK_ISSUER_URL", ""),
-		ClerkJWKSURL:      getEnv("CLERK_JWKS_URL", ""),
+		ClerkIssuerURL:    getEnvAny([]string{"TRADESLAB_CLERK_ISSUER_URL", "CLERK_ISSUER_URL"}, ""),
+		ClerkJWKSURL:      getEnvAny([]string{"TRADESLAB_CLERK_JWKS_URL", "CLERK_JWKS_URL"}, ""),
 		AuthMockMode:      getEnv("TRADESLAB_AUTH_MOCK_MODE", "") == "true",
 	}
 }
@@ -25,6 +25,16 @@ func Load() Config {
 func getEnv(key, fallback string) string {
 	if value := os.Getenv(key); value != "" {
 		return value
+	}
+
+	return fallback
+}
+
+func getEnvAny(keys []string, fallback string) string {
+	for _, key := range keys {
+		if value := os.Getenv(key); value != "" {
+			return value
+		}
 	}
 
 	return fallback

--- a/backend/internal/domain/session.go
+++ b/backend/internal/domain/session.go
@@ -11,3 +11,16 @@ type DemoSession struct {
 	CreatedAt  time.Time
 	LastUsedAt time.Time
 }
+
+type AppSession struct {
+	ID                string
+	UserID            string
+	WalletID          string
+	PrincipalKind     PrincipalKind
+	Token             string
+	IdleExpiresAt     time.Time
+	AbsoluteExpiresAt time.Time
+	CreatedAt         time.Time
+	LastUsedAt        time.Time
+	RevokedAt         *time.Time
+}

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/aidun/tradelab/backend/internal/domain"
+	"github.com/aidun/tradelab/backend/internal/logging"
 	orderservice "github.com/aidun/tradelab/backend/internal/service/order"
 	sessionservice "github.com/aidun/tradelab/backend/internal/service/session"
 )
@@ -44,13 +45,17 @@ type ActivityHistoryLister interface {
 type DemoSessionManager interface {
 	CreateDemoSession(ctx context.Context) (domain.DemoSession, error)
 	Authenticate(ctx context.Context, token string) (domain.DemoSession, error)
+	CreateRegisteredSession(ctx context.Context, userID string, walletID string) (domain.AppSession, error)
+	AuthenticateRegistered(ctx context.Context, token string) (domain.AppSession, error)
+	RevokeRegisteredSession(ctx context.Context, token string) error
 }
 
 type RegisteredAccountManager interface {
-	AuthenticateRegistered(ctx context.Context, token string) (domain.RegisteredAccount, error)
 	BootstrapRegisteredAccount(ctx context.Context, token string) (domain.RegisteredAccount, error)
 	UpgradeGuestSession(ctx context.Context, registeredToken string, guestToken string, preserveGuestData bool) (domain.RegisteredAccount, error)
 }
+
+const registeredSessionCookieName = "tradelab_app_session"
 
 func NewRouter(markets MarketLister, marketCandles MarketCandlesLister, orders OrderPlacer, portfolios PortfolioGetter, orderHistory OrderHistoryLister, activityHistory ActivityHistoryLister, sessions DemoSessionManager, registeredAccounts RegisteredAccountManager, logger *slog.Logger) http.Handler {
 	mux := http.NewServeMux()
@@ -129,19 +134,28 @@ func NewRouter(markets MarketLister, marketCandles MarketCandlesLister, orders O
 	})
 
 	mux.HandleFunc("POST /api/v1/account/bootstrap", func(w http.ResponseWriter, r *http.Request) {
-		token, ok := bearerToken(r.Header.Get("Authorization"))
+		clerkToken, ok := bearerToken(r.Header.Get("Authorization"))
 		if !ok {
 			logInfo(logger, "auth.registered_missing_bearer_token", "path", r.URL.Path)
 			writeError(w, http.StatusUnauthorized, "missing bearer token")
 			return
 		}
 
-		account, err := registeredAccounts.BootstrapRegisteredAccount(r.Context(), token)
+		account, err := registeredAccounts.BootstrapRegisteredAccount(r.Context(), clerkToken)
 		if err != nil {
 			logError(logger, "account.bootstrap_failed", err, "path", r.URL.Path)
 			writeError(w, http.StatusUnauthorized, "failed to bootstrap registered account")
 			return
 		}
+
+		appSession, err := sessions.CreateRegisteredSession(r.Context(), account.UserID, account.WalletID)
+		if err != nil {
+			logError(logger, "account.bootstrap_session_failed", err, "path", r.URL.Path, "user_id", account.UserID)
+			writeError(w, http.StatusInternalServerError, "failed to establish registered session")
+			return
+		}
+
+		writeRegisteredSessionCookie(w, r, appSession)
 
 		writeJSON(w, http.StatusOK, map[string]any{
 			"account": map[string]any{
@@ -156,7 +170,7 @@ func NewRouter(markets MarketLister, marketCandles MarketCandlesLister, orders O
 	})
 
 	mux.HandleFunc("POST /api/v1/account/upgrade", func(w http.ResponseWriter, r *http.Request) {
-		token, ok := bearerToken(r.Header.Get("Authorization"))
+		clerkToken, ok := bearerToken(r.Header.Get("Authorization"))
 		if !ok {
 			logInfo(logger, "auth.registered_missing_bearer_token", "path", r.URL.Path)
 			writeError(w, http.StatusUnauthorized, "missing bearer token")
@@ -178,7 +192,7 @@ func NewRouter(markets MarketLister, marketCandles MarketCandlesLister, orders O
 			return
 		}
 
-		account, err := registeredAccounts.UpgradeGuestSession(r.Context(), token, guestToken, payload.PreserveGuestData)
+		account, err := registeredAccounts.UpgradeGuestSession(r.Context(), clerkToken, guestToken, payload.PreserveGuestData)
 		if err != nil {
 			statusCode := http.StatusUnauthorized
 			if strings.Contains(err.Error(), "already exists") {
@@ -188,6 +202,15 @@ func NewRouter(markets MarketLister, marketCandles MarketCandlesLister, orders O
 			writeError(w, statusCode, err.Error())
 			return
 		}
+
+		appSession, err := sessions.CreateRegisteredSession(r.Context(), account.UserID, account.WalletID)
+		if err != nil {
+			logError(logger, "account.upgrade_session_failed", err, "path", r.URL.Path, "user_id", account.UserID)
+			writeError(w, http.StatusInternalServerError, "failed to establish registered session")
+			return
+		}
+
+		writeRegisteredSessionCookie(w, r, appSession)
 
 		writeJSON(w, http.StatusOK, map[string]any{
 			"account": map[string]any{
@@ -199,6 +222,19 @@ func NewRouter(markets MarketLister, marketCandles MarketCandlesLister, orders O
 				"mode":          "registered",
 			},
 		})
+	})
+
+	mux.HandleFunc("POST /api/v1/account/logout", func(w http.ResponseWriter, r *http.Request) {
+		if token, ok := registeredSessionCookieValue(r); ok {
+			if err := sessions.RevokeRegisteredSession(r.Context(), token); err != nil {
+				logError(logger, "account.logout_failed", err, "path", r.URL.Path)
+				writeError(w, http.StatusInternalServerError, "failed to clear registered session")
+				return
+			}
+		}
+
+		clearRegisteredSessionCookie(w, r)
+		w.WriteHeader(http.StatusNoContent)
 	})
 
 	mux.HandleFunc("GET /api/v1/portfolios/", func(w http.ResponseWriter, r *http.Request) {
@@ -307,10 +343,29 @@ func NewRouter(markets MarketLister, marketCandles MarketCandlesLister, orders O
 }
 
 func requirePrincipal(w http.ResponseWriter, r *http.Request, sessions DemoSessionManager, registeredAccounts RegisteredAccountManager, logger *slog.Logger) (domain.Principal, bool) {
+	if registeredToken, ok := registeredSessionCookieValue(r); ok {
+		appSession, err := sessions.AuthenticateRegistered(r.Context(), registeredToken)
+		if err == nil {
+			return domain.Principal{
+				Kind:      domain.PrincipalKindRegistered,
+				UserID:    appSession.UserID,
+				WalletID:  appSession.WalletID,
+				SessionID: appSession.ID,
+			}, true
+		}
+
+		clearRegisteredSessionCookie(w, r)
+		if !errors.Is(err, sessionservice.ErrInvalidAppSession) {
+			logError(logger, "auth.invalid_registered_session", err, "path", r.URL.Path, "status_code", http.StatusInternalServerError)
+			writeError(w, http.StatusInternalServerError, "invalid registered session")
+			return domain.Principal{}, false
+		}
+	}
+
 	token, ok := bearerToken(r.Header.Get("Authorization"))
 	if !ok {
-		logInfo(logger, "auth.missing_bearer_token", "path", r.URL.Path)
-		writeError(w, http.StatusUnauthorized, "missing bearer token")
+		logInfo(logger, "auth.missing_credentials", "path", r.URL.Path)
+		writeError(w, http.StatusUnauthorized, "missing session credentials")
 		return domain.Principal{}, false
 	}
 
@@ -330,21 +385,9 @@ func requirePrincipal(w http.ResponseWriter, r *http.Request, sessions DemoSessi
 		return domain.Principal{}, false
 	}
 
-	// Guest sessions stay the default path, but once that lookup says "not a guest token"
-	// we fall through to the registered-account verifier so both identity models can coexist.
-	account, registeredErr := registeredAccounts.AuthenticateRegistered(r.Context(), token)
-	if registeredErr != nil {
-		logError(logger, "auth.invalid_registered_account", registeredErr, "path", r.URL.Path, "status_code", http.StatusUnauthorized)
-		writeError(w, http.StatusUnauthorized, "invalid session token")
-		return domain.Principal{}, false
-	}
-
-	return domain.Principal{
-		Kind:        domain.PrincipalKindRegistered,
-		UserID:      account.UserID,
-		WalletID:    account.WalletID,
-		ClerkUserID: account.ClerkUserID,
-	}, true
+	logInfo(logger, "auth.invalid_guest_session", "path", r.URL.Path)
+	writeError(w, http.StatusUnauthorized, "invalid session token")
+	return domain.Principal{}, false
 }
 
 func bearerToken(header string) (string, bool) {
@@ -432,5 +475,47 @@ func logError(logger *slog.Logger, operation string, err error, args ...any) {
 		return
 	}
 
-	logger.Error(operation, append([]any{"operation", operation, "error", err}, args...)...)
+	logger.Error(operation, append([]any{"operation", operation, "error", logging.RedactError(err)}, args...)...)
+}
+
+func registeredSessionCookieValue(r *http.Request) (string, bool) {
+	cookie, err := r.Cookie(registeredSessionCookieName)
+	if err != nil || strings.TrimSpace(cookie.Value) == "" {
+		return "", false
+	}
+
+	return strings.TrimSpace(cookie.Value), true
+}
+
+func writeRegisteredSessionCookie(w http.ResponseWriter, r *http.Request, session domain.AppSession) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     registeredSessionCookieName,
+		Value:    session.Token,
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   shouldUseSecureCookies(r),
+		SameSite: http.SameSiteLaxMode,
+		Expires:  session.IdleExpiresAt,
+	})
+}
+
+func clearRegisteredSessionCookie(w http.ResponseWriter, r *http.Request) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     registeredSessionCookieName,
+		Value:    "",
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   shouldUseSecureCookies(r),
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   -1,
+		Expires:  time.Unix(0, 0),
+	})
+}
+
+func shouldUseSecureCookies(r *http.Request) bool {
+	if r.TLS != nil {
+		return true
+	}
+
+	return strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https")
 }

--- a/backend/internal/http/router_test.go
+++ b/backend/internal/http/router_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/aidun/tradelab/backend/internal/domain"
 	orderservice "github.com/aidun/tradelab/backend/internal/service/order"
-	sessionservice "github.com/aidun/tradelab/backend/internal/service/session"
 )
 
 func discardLogger() *slog.Logger {
@@ -218,7 +217,17 @@ func TestBootstrapRegisteredAccountRoute(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer registered-token")
 	recorder := httptest.NewRecorder()
 
-	NewRouter(fakeMarketLister{}, fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}, fakeSessionManager{}, fakeRegisteredAccountManager{
+	NewRouter(fakeMarketLister{}, fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}, fakeSessionManager{
+		appSession: domain.AppSession{
+			ID:            "app-session-1",
+			Token:         "cookie-token",
+			IdleExpiresAt: time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC),
+			LastUsedAt:    time.Date(2026, 3, 29, 12, 0, 0, 0, time.UTC),
+			PrincipalKind: domain.PrincipalKindRegistered,
+			UserID:        "user-registered",
+			WalletID:      "wallet-registered",
+		},
+	}, fakeRegisteredAccountManager{
 		account: domain.RegisteredAccount{
 			UserID:      "user-registered",
 			WalletID:    "wallet-registered",
@@ -235,6 +244,10 @@ func TestBootstrapRegisteredAccountRoute(t *testing.T) {
 	if !strings.Contains(recorder.Body.String(), `"mode":"registered"`) {
 		t.Fatalf("expected registered mode in response, got %s", recorder.Body.String())
 	}
+
+	if !strings.Contains(recorder.Header().Get("Set-Cookie"), registeredSessionCookieName+"=cookie-token") {
+		t.Fatalf("expected registered session cookie to be set, got %s", recorder.Header().Get("Set-Cookie"))
+	}
 }
 
 func TestUpgradeGuestAccountRoute(t *testing.T) {
@@ -244,7 +257,17 @@ func TestUpgradeGuestAccountRoute(t *testing.T) {
 	req.Header.Set("X-TradeLab-Guest-Token", "guest-token")
 	recorder := httptest.NewRecorder()
 
-	NewRouter(fakeMarketLister{}, fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}, fakeSessionManager{}, fakeRegisteredAccountManager{
+	NewRouter(fakeMarketLister{}, fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}, fakeSessionManager{
+		appSession: domain.AppSession{
+			ID:            "app-session-1",
+			Token:         "cookie-token",
+			IdleExpiresAt: time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC),
+			LastUsedAt:    time.Date(2026, 3, 29, 12, 0, 0, 0, time.UTC),
+			PrincipalKind: domain.PrincipalKindRegistered,
+			UserID:        "user-registered",
+			WalletID:      "wallet-registered",
+		},
+	}, fakeRegisteredAccountManager{
 		account: domain.RegisteredAccount{
 			UserID:      "user-registered",
 			WalletID:    "wallet-registered",
@@ -261,23 +284,40 @@ func TestUpgradeGuestAccountRoute(t *testing.T) {
 
 func TestOrdersRouteSupportsRegisteredAccounts(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/orders", nil)
-	req.Header.Set("Authorization", "Bearer registered-token")
+	req.AddCookie(&http.Cookie{Name: registeredSessionCookieName, Value: "cookie-token"})
 	recorder := httptest.NewRecorder()
 
 	NewRouter(fakeMarketLister{}, fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{
 		orders: []domain.Order{{ID: "order-registered", WalletID: "wallet-registered", MarketSymbol: "BTC/USDT"}},
 	}, fakeActivityHistoryLister{}, fakeSessionManager{
-		err: sessionservice.ErrInvalidSession,
-	}, fakeRegisteredAccountManager{
-		account: domain.RegisteredAccount{
-			UserID:      "user-registered",
-			WalletID:    "wallet-registered",
-			ClerkUserID: "clerk-user-1",
+		appSession: domain.AppSession{
+			ID:                "app-session-1",
+			UserID:            "user-registered",
+			WalletID:          "wallet-registered",
+			PrincipalKind:     domain.PrincipalKindRegistered,
+			IdleExpiresAt:     time.Date(2026, 4, 29, 11, 0, 0, 0, time.UTC),
+			AbsoluteExpiresAt: time.Date(2026, 4, 29, 11, 0, 0, 0, time.UTC),
 		},
-	}, discardLogger()).ServeHTTP(recorder, req)
+	}, fakeRegisteredAccountManager{}, discardLogger()).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", recorder.Code)
+	}
+}
+
+func TestLogoutRouteRevokesRegisteredCookie(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/account/logout", nil)
+	req.AddCookie(&http.Cookie{Name: registeredSessionCookieName, Value: "cookie-token"})
+	recorder := httptest.NewRecorder()
+
+	NewRouter(fakeMarketLister{}, fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}, fakeSessionManager{}, fakeRegisteredAccountManager{}, discardLogger()).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", recorder.Code)
+	}
+
+	if !strings.Contains(recorder.Header().Get("Set-Cookie"), registeredSessionCookieName+"=") {
+		t.Fatalf("expected registered session cookie to be cleared, got %s", recorder.Header().Get("Set-Cookie"))
 	}
 }
 
@@ -329,8 +369,12 @@ func (f fakeActivityHistoryLister) ListActivity(context.Context, string, int) ([
 }
 
 type fakeSessionManager struct {
-	session domain.DemoSession
-	err     error
+	session      domain.DemoSession
+	appSession   domain.AppSession
+	err          error
+	appErr       error
+	revokeErr    error
+	revokedToken string
 }
 
 func (f fakeSessionManager) CreateDemoSession(context.Context) (domain.DemoSession, error) {
@@ -341,13 +385,22 @@ func (f fakeSessionManager) Authenticate(context.Context, string) (domain.DemoSe
 	return f.session, f.err
 }
 
+func (f fakeSessionManager) CreateRegisteredSession(context.Context, string, string) (domain.AppSession, error) {
+	return f.appSession, f.appErr
+}
+
+func (f fakeSessionManager) AuthenticateRegistered(context.Context, string) (domain.AppSession, error) {
+	return f.appSession, f.appErr
+}
+
+func (f fakeSessionManager) RevokeRegisteredSession(_ context.Context, token string) error {
+	f.revokedToken = token
+	return f.revokeErr
+}
+
 type fakeRegisteredAccountManager struct {
 	account domain.RegisteredAccount
 	err     error
-}
-
-func (f fakeRegisteredAccountManager) AuthenticateRegistered(context.Context, string) (domain.RegisteredAccount, error) {
-	return f.account, f.err
 }
 
 func (f fakeRegisteredAccountManager) BootstrapRegisteredAccount(context.Context, string) (domain.RegisteredAccount, error) {

--- a/backend/internal/logging/logging.go
+++ b/backend/internal/logging/logging.go
@@ -4,6 +4,8 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"regexp"
+	"strings"
 )
 
 func NewJSONLogger(component string) *slog.Logger {
@@ -12,4 +14,34 @@ func NewJSONLogger(component string) *slog.Logger {
 
 func NewDiscardLogger(component string) *slog.Logger {
 	return slog.New(slog.NewJSONHandler(io.Discard, &slog.HandlerOptions{})).With("component", component)
+}
+
+var (
+	bearerPattern    = regexp.MustCompile(`(?i)bearer\s+[a-z0-9\-\._~\+/=]+`)
+	passwordPattern  = regexp.MustCompile(`(?i)(password=)([^&\s]+)`)
+	urlSecretPattern = regexp.MustCompile(`:\/\/([^:\s]+):([^@\s]+)@`)
+)
+
+func RedactString(value string) string {
+	redacted := bearerPattern.ReplaceAllString(value, "Bearer [REDACTED]")
+	redacted = passwordPattern.ReplaceAllString(redacted, "${1}[REDACTED]")
+	redacted = urlSecretPattern.ReplaceAllString(redacted, "://$1:[REDACTED]@")
+	redacted = strings.ReplaceAll(redacted, "Authorization", "Authorization[REDACTED]")
+	return redacted
+}
+
+func RedactError(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	return RedactString(err.Error())
+}
+
+func TruncateID(value string) string {
+	if len(value) <= 8 {
+		return value
+	}
+
+	return value[:8]
 }

--- a/backend/internal/logging/logging_test.go
+++ b/backend/internal/logging/logging_test.go
@@ -1,0 +1,28 @@
+package logging
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRedactStringMasksBearerTokensAndPasswords(t *testing.T) {
+	input := "Authorization: Bearer abc.def password=secret postgres://user:supersecret@localhost:5432/db"
+	redacted := RedactString(input)
+
+	if redacted == input {
+		t.Fatalf("expected string to be redacted")
+	}
+
+	if containsAny(redacted, []string{"abc.def", "secret", "supersecret"}) {
+		t.Fatalf("expected sensitive values to be removed, got %s", redacted)
+	}
+}
+
+func containsAny(value string, needles []string) bool {
+	for _, needle := range needles {
+		if needle != "" && strings.Contains(value, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/service/account/service.go
+++ b/backend/internal/service/account/service.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 
 	"github.com/aidun/tradelab/backend/internal/domain"
+	"github.com/aidun/tradelab/backend/internal/logging"
 	"github.com/aidun/tradelab/backend/internal/store"
 )
 
@@ -105,7 +106,7 @@ func (s *Service) verifyToken(ctx context.Context, token string) (domain.Registe
 
 	identity, err := s.verifier.VerifyToken(ctx, token)
 	if err != nil {
-		s.logInfo("verify_registered_token.failed", "reason", err.Error())
+		s.logInfo("verify_registered_token.failed", "reason", "verification_failed")
 		return domain.RegisteredIdentity{}, fmt.Errorf("%w: %v", ErrInvalidRegisteredToken, err)
 	}
 
@@ -125,5 +126,5 @@ func (s *Service) logError(operation string, err error, args ...any) {
 		return
 	}
 
-	s.logger.Error(operation, append([]any{"operation", operation, "error", err}, args...)...)
+	s.logger.Error(operation, append([]any{"operation", operation, "error", logging.RedactError(err)}, args...)...)
 }

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -7,10 +7,12 @@ import (
 	"time"
 
 	"github.com/aidun/tradelab/backend/internal/domain"
+	"github.com/aidun/tradelab/backend/internal/logging"
 	"github.com/aidun/tradelab/backend/internal/store"
 )
 
 var ErrInvalidSession = errors.New("invalid session token")
+var ErrInvalidAppSession = errors.New("invalid app session")
 
 type Clock interface {
 	Now() time.Time
@@ -23,16 +25,18 @@ func (realClock) Now() time.Time {
 }
 
 type Service struct {
-	sessions store.DemoSessionRepository
-	logger   *slog.Logger
-	clock    Clock
+	sessions    store.DemoSessionRepository
+	appSessions store.AppSessionRepository
+	logger      *slog.Logger
+	clock       Clock
 }
 
-func NewService(sessions store.DemoSessionRepository, logger *slog.Logger) *Service {
+func NewService(sessions store.DemoSessionRepository, appSessions store.AppSessionRepository, logger *slog.Logger) *Service {
 	return &Service{
-		sessions: sessions,
-		logger:   logger,
-		clock:    realClock{},
+		sessions:    sessions,
+		appSessions: appSessions,
+		logger:      logger,
+		clock:       realClock{},
 	}
 }
 
@@ -68,6 +72,56 @@ func (s *Service) Authenticate(ctx context.Context, token string) (domain.DemoSe
 	return session, nil
 }
 
+func (s *Service) CreateRegisteredSession(ctx context.Context, userID string, walletID string) (domain.AppSession, error) {
+	if s.appSessions == nil {
+		return domain.AppSession{}, ErrInvalidAppSession
+	}
+
+	session, err := s.appSessions.CreateRegisteredSession(ctx, userID, walletID)
+	if err != nil {
+		s.logError("create_registered_session.failed", err, "user_id", userID, "wallet_id", walletID)
+		return domain.AppSession{}, err
+	}
+
+	s.logInfo("create_registered_session.success", "session_id", session.ID, "wallet_id", session.WalletID)
+	return session, nil
+}
+
+func (s *Service) AuthenticateRegistered(ctx context.Context, token string) (domain.AppSession, error) {
+	if token == "" || s.appSessions == nil {
+		return domain.AppSession{}, ErrInvalidAppSession
+	}
+
+	session, err := s.appSessions.GetRegisteredSessionByToken(ctx, token)
+	if err != nil {
+		s.logInfo("authenticate_registered_session.invalid", "reason", "lookup_failed")
+		return domain.AppSession{}, ErrInvalidAppSession
+	}
+
+	now := s.clock.Now()
+	if session.RevokedAt != nil || !session.IdleExpiresAt.After(now) || !session.AbsoluteExpiresAt.After(now) {
+		s.logInfo("authenticate_registered_session.invalid", "session_id", session.ID, "reason", "expired_or_revoked")
+		return domain.AppSession{}, ErrInvalidAppSession
+	}
+
+	s.logInfo("authenticate_registered_session.success", "session_id", session.ID, "wallet_id", session.WalletID)
+	return session, nil
+}
+
+func (s *Service) RevokeRegisteredSession(ctx context.Context, token string) error {
+	if token == "" || s.appSessions == nil {
+		return nil
+	}
+
+	if err := s.appSessions.RevokeRegisteredSessionByToken(ctx, token); err != nil {
+		s.logError("revoke_registered_session.failed", err)
+		return err
+	}
+
+	s.logInfo("revoke_registered_session.success")
+	return nil
+}
+
 func (s *Service) logInfo(operation string, args ...any) {
 	if s.logger == nil {
 		return
@@ -81,5 +135,5 @@ func (s *Service) logError(operation string, err error, args ...any) {
 		return
 	}
 
-	s.logger.Error(operation, append([]any{"operation", operation, "error", err}, args...)...)
+	s.logger.Error(operation, append([]any{"operation", operation, "error", logging.RedactError(err)}, args...)...)
 }

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -13,7 +13,7 @@ import (
 func TestCreateDemoSessionReturnsRepositorySession(t *testing.T) {
 	service := NewService(fakeDemoSessionRepository{
 		session: domain.DemoSession{ID: "session-1", WalletID: "wallet-1"},
-	}, logging.NewDiscardLogger("session_service_test"))
+	}, fakeAppSessionRepository{}, logging.NewDiscardLogger("session_service_test"))
 
 	session, err := service.CreateDemoSession(context.Background())
 	if err != nil {
@@ -33,7 +33,7 @@ func TestAuthenticateRejectsExpiredSession(t *testing.T) {
 			WalletID:  "wallet-1",
 			ExpiresAt: time.Date(2026, 3, 29, 11, 0, 0, 0, time.UTC),
 		},
-	}, logging.NewDiscardLogger("session_service_test"))
+	}, fakeAppSessionRepository{}, logging.NewDiscardLogger("session_service_test"))
 	service.clock = fakeClock{now: time.Date(2026, 3, 29, 12, 0, 0, 0, time.UTC)}
 
 	if _, err := service.Authenticate(context.Background(), "token-1"); !errors.Is(err, ErrInvalidSession) {
@@ -44,10 +44,66 @@ func TestAuthenticateRejectsExpiredSession(t *testing.T) {
 func TestAuthenticateRejectsLookupErrors(t *testing.T) {
 	service := NewService(fakeDemoSessionRepository{
 		err: errors.New("lookup failed"),
-	}, logging.NewDiscardLogger("session_service_test"))
+	}, fakeAppSessionRepository{}, logging.NewDiscardLogger("session_service_test"))
 
 	if _, err := service.Authenticate(context.Background(), "token-1"); !errors.Is(err, ErrInvalidSession) {
 		t.Fatalf("expected ErrInvalidSession, got %v", err)
+	}
+}
+
+func TestCreateRegisteredSessionReturnsRepositorySession(t *testing.T) {
+	service := NewService(fakeDemoSessionRepository{}, fakeAppSessionRepository{
+		session: domain.AppSession{ID: "app-session-1", WalletID: "wallet-1"},
+	}, logging.NewDiscardLogger("session_service_test"))
+
+	session, err := service.CreateRegisteredSession(context.Background(), "user-1", "wallet-1")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if session.ID != "app-session-1" {
+		t.Fatalf("expected app-session-1, got %s", session.ID)
+	}
+}
+
+func TestAuthenticateRegisteredRejectsExpiredAppSession(t *testing.T) {
+	service := NewService(fakeDemoSessionRepository{}, fakeAppSessionRepository{
+		session: domain.AppSession{
+			ID:                "app-session-1",
+			WalletID:          "wallet-1",
+			IdleExpiresAt:     time.Date(2026, 3, 29, 11, 0, 0, 0, time.UTC),
+			AbsoluteExpiresAt: time.Date(2026, 4, 29, 11, 0, 0, 0, time.UTC),
+		},
+	}, logging.NewDiscardLogger("session_service_test"))
+	service.clock = fakeClock{now: time.Date(2026, 3, 29, 12, 0, 0, 0, time.UTC)}
+
+	if _, err := service.AuthenticateRegistered(context.Background(), "token-1"); !errors.Is(err, ErrInvalidAppSession) {
+		t.Fatalf("expected ErrInvalidAppSession, got %v", err)
+	}
+}
+
+func TestAuthenticateRegisteredRejectsRevokedSession(t *testing.T) {
+	revokedAt := time.Date(2026, 3, 29, 10, 0, 0, 0, time.UTC)
+	service := NewService(fakeDemoSessionRepository{}, fakeAppSessionRepository{
+		session: domain.AppSession{
+			ID:                "app-session-1",
+			WalletID:          "wallet-1",
+			IdleExpiresAt:     time.Date(2026, 4, 29, 11, 0, 0, 0, time.UTC),
+			AbsoluteExpiresAt: time.Date(2026, 4, 29, 11, 0, 0, 0, time.UTC),
+			RevokedAt:         &revokedAt,
+		},
+	}, logging.NewDiscardLogger("session_service_test"))
+
+	if _, err := service.AuthenticateRegistered(context.Background(), "token-1"); !errors.Is(err, ErrInvalidAppSession) {
+		t.Fatalf("expected ErrInvalidAppSession, got %v", err)
+	}
+}
+
+func TestRevokeRegisteredSessionIsIdempotentForMissingToken(t *testing.T) {
+	service := NewService(fakeDemoSessionRepository{}, fakeAppSessionRepository{}, logging.NewDiscardLogger("session_service_test"))
+
+	if err := service.RevokeRegisteredSession(context.Background(), ""); err != nil {
+		t.Fatalf("expected no error, got %v", err)
 	}
 }
 
@@ -62,6 +118,25 @@ func (f fakeDemoSessionRepository) CreateDemoSession(context.Context) (domain.De
 
 func (f fakeDemoSessionRepository) GetByToken(context.Context, string) (domain.DemoSession, error) {
 	return f.session, f.err
+}
+
+type fakeAppSessionRepository struct {
+	session   domain.AppSession
+	err       error
+	revoked   string
+	revokeErr error
+}
+
+func (f fakeAppSessionRepository) CreateRegisteredSession(context.Context, string, string) (domain.AppSession, error) {
+	return f.session, f.err
+}
+
+func (f fakeAppSessionRepository) GetRegisteredSessionByToken(context.Context, string) (domain.AppSession, error) {
+	return f.session, f.err
+}
+
+func (f fakeAppSessionRepository) RevokeRegisteredSessionByToken(context.Context, string) error {
+	return f.revokeErr
 }
 
 type fakeClock struct {

--- a/backend/internal/store/postgres/postgres.go
+++ b/backend/internal/store/postgres/postgres.go
@@ -190,6 +190,98 @@ func (r *DemoSessionRepository) GetByToken(ctx context.Context, token string) (d
 	return session, nil
 }
 
+type AppSessionRepository struct {
+	db *sql.DB
+}
+
+func NewAppSessionRepository(db *sql.DB) *AppSessionRepository {
+	return &AppSessionRepository{db: db}
+}
+
+func (r *AppSessionRepository) CreateRegisteredSession(ctx context.Context, userID string, walletID string) (domain.AppSession, error) {
+	now := time.Now().UTC()
+	idleExpiresAt := now.Add(7 * 24 * time.Hour)
+	absoluteExpiresAt := now.Add(30 * 24 * time.Hour)
+	sessionID := newUUID()
+	token, tokenHash, err := newSessionToken()
+	if err != nil {
+		return domain.AppSession{}, err
+	}
+
+	if _, err := r.db.ExecContext(ctx, `
+		UPDATE app_sessions
+		SET revoked_at = NOW()
+		WHERE user_id = $1 AND principal_kind = $2 AND revoked_at IS NULL
+	`, userID, domain.PrincipalKindRegistered); err != nil {
+		return domain.AppSession{}, err
+	}
+
+	if _, err := r.db.ExecContext(ctx, `
+		INSERT INTO app_sessions (
+			id,
+			user_id,
+			wallet_id,
+			principal_kind,
+			token_hash,
+			idle_expires_at,
+			absolute_expires_at,
+			created_at,
+			last_used_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $8)
+	`, sessionID, userID, walletID, domain.PrincipalKindRegistered, tokenHash, idleExpiresAt, absoluteExpiresAt, now); err != nil {
+		return domain.AppSession{}, err
+	}
+
+	return domain.AppSession{
+		ID:                sessionID,
+		UserID:            userID,
+		WalletID:          walletID,
+		PrincipalKind:     domain.PrincipalKindRegistered,
+		Token:             token,
+		IdleExpiresAt:     idleExpiresAt,
+		AbsoluteExpiresAt: absoluteExpiresAt,
+		CreatedAt:         now,
+		LastUsedAt:        now,
+	}, nil
+}
+
+func (r *AppSessionRepository) GetRegisteredSessionByToken(ctx context.Context, token string) (domain.AppSession, error) {
+	var session domain.AppSession
+	tokenHash := hashToken(token)
+
+	err := r.db.QueryRowContext(ctx, `
+		UPDATE app_sessions
+		SET last_used_at = NOW(), idle_expires_at = NOW() + INTERVAL '7 days'
+		WHERE token_hash = $1
+		  AND revoked_at IS NULL
+		RETURNING id, user_id, wallet_id, principal_kind, idle_expires_at, absolute_expires_at, created_at, last_used_at, revoked_at
+	`, tokenHash).Scan(
+		&session.ID,
+		&session.UserID,
+		&session.WalletID,
+		&session.PrincipalKind,
+		&session.IdleExpiresAt,
+		&session.AbsoluteExpiresAt,
+		&session.CreatedAt,
+		&session.LastUsedAt,
+		&session.RevokedAt,
+	)
+	if err != nil {
+		return domain.AppSession{}, err
+	}
+
+	return session, nil
+}
+
+func (r *AppSessionRepository) RevokeRegisteredSessionByToken(ctx context.Context, token string) error {
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE app_sessions
+		SET revoked_at = NOW()
+		WHERE token_hash = $1 AND revoked_at IS NULL
+	`, hashToken(token))
+	return err
+}
+
 type RegisteredAccountRepository struct {
 	db *sql.DB
 }

--- a/backend/internal/store/store.go
+++ b/backend/internal/store/store.go
@@ -20,6 +20,12 @@ type DemoSessionRepository interface {
 	GetByToken(ctx context.Context, token string) (domain.DemoSession, error)
 }
 
+type AppSessionRepository interface {
+	CreateRegisteredSession(ctx context.Context, userID string, walletID string) (domain.AppSession, error)
+	GetRegisteredSessionByToken(ctx context.Context, token string) (domain.AppSession, error)
+	RevokeRegisteredSessionByToken(ctx context.Context, token string) error
+}
+
 type RegisteredAccountRepository interface {
 	GetByClerkUserID(ctx context.Context, clerkUserID string) (domain.RegisteredAccount, error)
 	BootstrapRegisteredAccount(ctx context.Context, identity domain.RegisteredIdentity) (domain.RegisteredAccount, error)

--- a/backend/migrations/000008_add_app_sessions.down.sql
+++ b/backend/migrations/000008_add_app_sessions.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS app_sessions;

--- a/backend/migrations/000008_add_app_sessions.up.sql
+++ b/backend/migrations/000008_add_app_sessions.up.sql
@@ -1,0 +1,16 @@
+CREATE TABLE app_sessions (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    wallet_id TEXT NOT NULL REFERENCES wallets(id) ON DELETE CASCADE,
+    principal_kind TEXT NOT NULL,
+    token_hash TEXT NOT NULL UNIQUE,
+    idle_expires_at TIMESTAMPTZ NOT NULL,
+    absolute_expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_used_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    revoked_at TIMESTAMPTZ NULL
+);
+
+CREATE INDEX idx_app_sessions_user_id ON app_sessions(user_id);
+CREATE INDEX idx_app_sessions_wallet_id ON app_sessions(wallet_id);
+CREATE INDEX idx_app_sessions_token_hash ON app_sessions(token_hash);

--- a/docs/account-lifecycle.md
+++ b/docs/account-lifecycle.md
@@ -54,6 +54,7 @@ The upgrade path now lets the user choose whether:
 
 - identity re-authentication happens through Clerk
 - durable product data remains attached to the registered account
+- TradeLab app-session loss does not destroy account ownership, but it does require re-authentication
 
 ### Logout
 

--- a/docs/ai-metadata.json
+++ b/docs/ai-metadata.json
@@ -38,8 +38,10 @@
   ],
   "key_workflows": [
     "demo session creation",
+    "guest session persistence in sessionStorage only",
     "guest-to-registered account upgrade with preserve-or-fresh choice",
-    "registered account bootstrap through Clerk-backed identity",
+    "registered account bootstrap through Clerk-backed identity and HttpOnly app-session establishment",
+    "registered account logout with app-session revocation",
     "authenticated paper-trading API access",
     "server-authoritative market buy execution",
     "market-data fetch with bounded stale fallback",
@@ -58,6 +60,7 @@
     "clerk_architecture": "docs/clerk-architecture.md",
     "auth_flows": "docs/auth-flows.md",
     "account_lifecycle": "docs/account-lifecycle.md",
+    "security_model": "docs/security-model.md",
     "product": "docs/PRD.md",
     "roadmap": "docs/roadmap.md",
     "data_model": "docs/data-model.md",
@@ -100,7 +103,10 @@
       "GET /api/v1/activity",
       "POST /api/v1/orders"
     ],
-    "auth_model": "Bearer token from either a guest demo session or a Clerk-backed registered account, with guest mode as the default entry path"
+    "auth_model": "Guest routes use backend-issued bearer tokens scoped to the browser session, while registered routes use Clerk-backed bootstrap plus a TradeLab HttpOnly app-session cookie",
+    "session_security_routes": [
+      "POST /api/v1/account/logout"
+    ]
   },
   "quality_gates": {
     "ci_jobs": [
@@ -189,15 +195,16 @@
     "product_requirements_doc": "docs/onboarding-requirements.md"
   },
   "identity_roadmap": {
-    "current_state": "guest demo sessions plus Clerk-backed registered accounts",
-    "target_state": "guest mode plus hardened Clerk-backed registered accounts with stronger session security in Phase 3",
+    "current_state": "guest demo sessions plus Clerk-backed registered accounts with TradeLab-managed app sessions",
+    "target_state": "guest mode plus hardened Clerk-backed registered accounts with app-session expiry, revocation, and redaction controls",
     "managed_auth_provider": "Clerk",
     "social_login_targets": ["Google", "Apple"],
     "documentation": [
       "docs/authentication-model.md",
       "docs/clerk-architecture.md",
       "docs/auth-flows.md",
-      "docs/account-lifecycle.md"
+      "docs/account-lifecycle.md",
+      "docs/security-model.md"
     ]
   },
   "documentation_assets": {
@@ -313,7 +320,8 @@
       "docs/ai-metadata.json",
       "docs/authentication-model.md",
       "docs/clerk-architecture.md",
-      "docs/account-lifecycle.md"
+      "docs/account-lifecycle.md",
+      "docs/security-model.md"
     ],
     "operator_docs": [
       "docs/deployment.md",
@@ -425,6 +433,7 @@
           "update docs/clerk-architecture.md",
           "update docs/auth-flows.md",
           "update docs/account-lifecycle.md",
+          "update docs/security-model.md",
           "update docs/ai-metadata.json"
         ],
         "conditional_followups": [
@@ -588,6 +597,7 @@
         "scenario": "Change the authentication model or social login providers",
         "followups": [
           "update auth planning docs",
+          "update docs/security-model.md",
           "update README identity roadmap section",
           "update docs/ai-metadata.json",
           "review onboarding and operator docs for trust-boundary changes"

--- a/docs/auth-flows.md
+++ b/docs/auth-flows.md
@@ -31,7 +31,8 @@ Goal:
 3. User signs up with Google, Apple, or another enabled provider.
 4. TradeLab asks whether guest demo data should be preserved or discarded.
 5. TradeLab creates or links the internal user record.
-6. TradeLab initializes the durable demo account context.
+6. TradeLab establishes a registered `HttpOnly` app session.
+7. TradeLab initializes the durable demo account context.
 
 Goal:
 
@@ -42,7 +43,8 @@ Goal:
 1. User returns to TradeLab.
 2. Clerk authenticates the user.
 3. The backend resolves the internal user and account context.
-4. The product opens into the user-owned demo environment without forcing guest re-entry.
+4. The backend establishes or refreshes the registered app session.
+5. The product opens into the user-owned demo environment without forcing guest re-entry.
 
 Goal:
 
@@ -51,9 +53,10 @@ Goal:
 ## Flow 4. Logout
 
 1. User signs out from the account controls.
-2. Clerk session is terminated in the frontend.
-3. Any active registered-account application context is cleared.
-4. TradeLab falls back to a new guest demo session automatically.
+2. TradeLab revokes the registered app session.
+3. Clerk session is terminated in the frontend.
+4. Any active registered-account application context is cleared.
+5. TradeLab falls back to a new guest demo session automatically.
 
 Goal:
 

--- a/docs/authentication-model.md
+++ b/docs/authentication-model.md
@@ -100,9 +100,14 @@ Registered accounts should own:
 TradeLab separates:
 
 - `identity`: handled by Clerk
-- `application demo session`: handled by the TradeLab backend
+- `application session`: handled by the TradeLab backend
 
-This means a registered user still works inside a demo account context, but that context is linked to a durable Clerk identity instead of existing only as an anonymous guest token.
+This means:
+
+- guest users continue to work through a browser-visible guest token
+- registered users work through a backend-issued app session stored in an `HttpOnly` cookie
+
+The product keeps Clerk as the identity provider, but TradeLab now owns the authorization session for registered users.
 
 ## Future compatibility
 

--- a/docs/clerk-architecture.md
+++ b/docs/clerk-architecture.md
@@ -30,6 +30,7 @@ The Go backend now:
 - trusts only verified Clerk identity data for registered-account routes
 - map Clerk user IDs to internal TradeLab users
 - create or load the primary demo wallet for registered users
+- create TradeLab app sessions for registered users after Clerk verification
 - keep authorization logic server-side
 - avoid trusting raw client claims for wallet ownership or account identity
 
@@ -41,6 +42,7 @@ Instead:
 
 - Clerk verifies the user at the edge or frontend boundary
 - the backend verifies the authenticated identity context for protected registered-account routes through Clerk JWT verification or explicit mock mode
+- the backend then establishes an opaque registered app session for normal product use
 - TradeLab maps that identity to internal state such as user IDs, wallets, and portfolios
 
 ## Guest mode coexistence
@@ -51,7 +53,7 @@ This implies:
 
 - guest session creation remains available
 - guest sessions are treated as temporary and low-trust
-- registered mode uses verified external identity and durable internal ownership
+- registered mode uses verified external identity plus durable internal ownership through HttpOnly app sessions
 
 ## Route model
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -74,6 +74,12 @@ These environment variables affect the Next.js frontend runtime and rewrites.
 | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | optional | before frontend startup when you want the real Clerk UI and token flow in the browser | empty | frontend Clerk provider |
 | `NEXT_PUBLIC_AUTH_MOCK_MODE` | optional | before frontend startup in local or CI runs when mock Google/Apple auth should replace live Clerk configuration | `false` | frontend auth provider wrapper |
 
+Security notes:
+
+- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` is frontend-safe
+- Clerk secret material must stay server-side and must not be committed or exposed through browser env vars
+- `TRADESLAB_AUTH_MOCK_MODE` and `NEXT_PUBLIC_AUTH_MOCK_MODE` are development and CI switches only and must not be enabled in production manifests
+
 Recommended local default:
 
 - leave `NEXT_PUBLIC_API_BASE_URL` unset

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -132,7 +132,7 @@ kubectl kustomize deploy/kubernetes/overlays/production
 - `frontend/components`: UI components, including the trading dashboard
 - `frontend/lib`: API client code and shared helpers
 - `frontend/lib/tradelab-auth.tsx`: auth provider boundary for guest, mock, and Clerk-backed registered modes
-- `frontend/lib/use-account-session.ts`: guest-plus-registered account orchestration
+- `frontend/lib/use-account-session.ts`: guest-plus-registered account orchestration plus guest session refresh logic
 - `frontend/__tests__`: component and workflow tests
 - `frontend/scripts`: utility scripts, including documentation screenshot generation
 
@@ -209,6 +209,7 @@ When making changes:
 - `docs/installation-validation.md` defines the required smoke path for local and deployed environments
 - `docs/onboarding-requirements.md` captures the intended guest-first product onboarding behavior
 - `docs/authentication-model.md`, `docs/clerk-architecture.md`, `docs/auth-flows.md`, and `docs/account-lifecycle.md` define the implemented guest-plus-registered identity surface
+- `docs/security-model.md` is the source of truth for session, secret, redaction, and sensitive-data boundaries
 - `docs/system-operations.md` is the runtime and operator source of truth
 - `docs/developer-guide.md` is the contributor source of truth
 - `docs/user-guide.md` is the user-facing walkthrough with screenshots
@@ -233,4 +234,4 @@ When making changes, consult the `artifact_groups` and `change_management` secti
 - backend request and service flow now emits structured JSON logs through `log/slog`
 - frontend quality gates now include Playwright coverage for core dashboard journeys
 - release-ready Kubernetes output should use immutable release tags, not rely on `latest`
-- protected API routes now accept either guest demo-session bearer tokens or Clerk-backed registered account bearer tokens
+- protected API routes now accept guest bearer tokens or registered HttpOnly app-session cookies, depending on the principal type

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -1,0 +1,137 @@
+# Security Model
+
+## Purpose
+
+This document defines the current security posture for TradeLab across browser storage, sessions, secrets, logs, and sensitive data handling.
+
+TradeLab remains a demo-only product, but it still enforces explicit security boundaries for guest sessions, registered accounts, backend sessions, and operator-managed secrets.
+
+## Identity and session model
+
+TradeLab now uses two identity layers:
+
+- `Clerk` for external identity
+- `TradeLab app sessions` for backend authorization
+
+### Guest mode
+
+- guest sessions are created by the backend
+- guest session tokens are visible to the browser
+- guest tokens are stored in `sessionStorage` only
+- guest tokens are never intended to survive browser-session shutdown
+
+### Registered mode
+
+- Clerk authenticates the user
+- the backend verifies the Clerk token during bootstrap or upgrade
+- the backend creates an opaque TradeLab app session
+- the browser receives the registered app session only through an `HttpOnly` cookie
+- frontend code does not store or read the registered app-session token directly
+
+## Session lifecycle rules
+
+### Guest sessions
+
+- guest sessions remain temporary and lower-trust
+- guest expiry is bounded
+- invalid guest session behavior should create a new guest session with explicit UX messaging
+
+### Registered app sessions
+
+- registered app sessions use an idle timeout and an absolute lifetime
+- a new registered app session is created on login/bootstrap and on guest upgrade
+- older active registered sessions for the same user are revoked when a new one is created
+- logout revokes the current registered app session immediately
+- expired or revoked registered sessions require re-authentication through Clerk
+
+## Browser storage rules
+
+### Allowed browser-visible data
+
+- guest session token in `sessionStorage`
+- non-sensitive UI hints such as account mode or display name when needed
+- development-only mock-auth state
+
+### Forbidden browser-visible data
+
+- registered app-session token
+- database credentials
+- backend secret material
+- Clerk secret keys
+
+## Secret handling policy
+
+### Local development
+
+- secrets may exist only in ignored env files or local shell environment
+- no secret-bearing file should be committed into repo-tracked state
+
+### Development Kubernetes
+
+- secret values come from ignored local secret inputs only
+- mock auth may be enabled for development and CI, but it is not a production contract
+
+### Production
+
+- production secrets come from an external secret store only
+- publishable Clerk keys may be exposed to the frontend
+- Clerk secret material and database credentials stay server-side only
+
+### CI and release
+
+- secrets come from GitHub Actions secret boundaries or registry auth
+- workflows must never echo secret values or raw credentials into logs
+
+## Logging and redaction rules
+
+The backend must never log:
+
+- raw guest session tokens
+- Clerk bearer tokens
+- cookies or cookie values
+- `Authorization` headers
+- passwords
+- raw database URLs with embedded credentials
+- secret values from env or operator input
+
+The backend may log:
+
+- session ids
+- wallet ids
+- user ids
+- truncated external identity ids
+- sanitized error strings
+
+## Sensitive-data inventory
+
+| Data | Where it exists | Browser-visible | Purpose | Retention expectation |
+| --- | --- | --- | --- | --- |
+| guest session token | backend response + browser `sessionStorage` | yes | guest authorization | browser session only |
+| guest session hash | PostgreSQL `demo_sessions` | no | guest session lookup | until expiry/cleanup |
+| registered app-session cookie token | browser cookie | no to JS | registered authorization | until idle/absolute expiry or logout |
+| registered app-session hash | PostgreSQL `app_sessions` | no | registered session lookup and revocation | until expiry/cleanup |
+| Clerk user id | PostgreSQL `users.clerk_user_id` | not by default | durable identity mapping | long-lived account data |
+| email and display name | PostgreSQL `users` and frontend UI | display name yes, email only when intentionally surfaced | account identity and UX | long-lived account data |
+| database credentials | env / secret store | no | infrastructure access | operator-managed |
+
+## Mock-auth boundary
+
+Mock auth exists only for:
+
+- local development
+- automated frontend tests
+- CI flows that need deterministic sign-in behavior
+
+Mock auth must not:
+
+- be enabled in production manifests
+- be documented as a production feature
+- be treated as a user-facing identity mode
+
+## Related documentation
+
+- [authentication-model.md](authentication-model.md)
+- [clerk-architecture.md](clerk-architecture.md)
+- [deployment.md](deployment.md)
+- [system-operations.md](system-operations.md)
+- [developer-guide.md](developer-guide.md)

--- a/docs/system-operations.md
+++ b/docs/system-operations.md
@@ -64,6 +64,8 @@ Secret-bearing values should not be committed directly into base manifests.
 - development secrets come from `deploy/kubernetes/overlays/development/.env.database`
 - production secrets come from the configured external secret store
 - database credentials and `DATABASE_URL` are the primary required runtime secrets today
+- Clerk publishable keys are frontend-safe, but Clerk secret material must remain server-side only
+- mock-auth flags are development and CI-only controls and must not be treated as production runtime settings
 
 ## Deployment flow
 
@@ -173,6 +175,8 @@ For a release-focused view of published artifacts and release meaning, see [rele
   Backend may fall back to stale market data for a bounded period; after that, market-dependent actions can fail explicitly.
 - `identity configuration failure`
   Usually visible as missing registered-account bootstrap, rejected Clerk bearer tokens, or an absent social-login surface when auth was expected.
+- `session security failure`
+  Usually visible as missing or cleared registered app-session cookies, repeated logout loops, or guest-session refresh after an unauthorized response.
 - `release packaging failure`
   Usually visible in GitHub Actions during image publication or manifest rendering.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -40,13 +40,13 @@ The dashboard combines the main trading surfaces in one place:
 
 ### 1. Start a demo session
 
-When the app opens, TradeLab creates a demo session in the background and stores it locally in the browser for the current user journey.
+When the app opens, TradeLab creates a demo session in the background and keeps it only for the current browser session.
 
 What this enables:
 
 - access to a demo wallet
 - access to protected portfolio and order routes
-- repeat visits without re-creating the session until it expires
+- repeat use during the current browser session until it expires
 
 ### 2. Upgrade to a registered demo account
 
@@ -62,6 +62,8 @@ If you sign in from a guest session, the upgrade prompt asks whether to:
 
 - keep guest demo data
 - start fresh
+
+Registered access uses a secure server-managed session after sign-in. The browser UI does not need a visible registered account token.
 
 ### 3. Inspect a market
 

--- a/frontend/__tests__/home.test.tsx
+++ b/frontend/__tests__/home.test.tsx
@@ -226,6 +226,7 @@ function installFetchMock(scenario: FetchScenario = {}) {
 describe("Hero", () => {
   beforeEach(() => {
     window.localStorage.clear();
+    window.sessionStorage.clear();
   });
 
   afterEach(() => {
@@ -249,6 +250,18 @@ describe("Hero", () => {
 
     expect(screen.getByText(/run demo buy/i)).toBeInTheDocument();
     expect(screen.getByText(/demo buy recorded/i)).toBeInTheDocument();
+  });
+
+  it("stores guest session state in sessionStorage instead of localStorage", async () => {
+    installFetchMock();
+
+    render(<Hero />);
+
+    await waitFor(() => {
+      expect(window.sessionStorage.getItem("tradelab.demo-session")).toBeTruthy();
+    });
+
+    expect(window.localStorage.getItem("tradelab.demo-session")).toBeNull();
   });
 
   it("refreshes only chart data when the interval changes", async () => {

--- a/frontend/components/market-dashboard.tsx
+++ b/frontend/components/market-dashboard.tsx
@@ -6,8 +6,7 @@ import {
   placeMarketBuy,
   type Candle,
   type CandleFeed,
-  type MarketDataMeta,
-  type RegisteredAccount
+  type MarketDataMeta
 } from "@/lib/api";
 import { AuthEntryActions, AuthStatusControls, useTradeLabAuth } from "@/lib/tradelab-auth";
 import { useAccountSession } from "@/lib/use-account-session";
@@ -252,7 +251,7 @@ export function MarketDashboard() {
 
     try {
       const token = await activeAccessToken();
-      if (!token || !activeWalletID) {
+      if (!activeWalletID) {
         throw new Error("TradeLab session is not ready yet");
       }
 

--- a/frontend/e2e/home.spec.ts
+++ b/frontend/e2e/home.spec.ts
@@ -6,6 +6,7 @@ test.beforeEach(async ({ page }) => {
 
   await page.addInitScript(() => {
     window.localStorage.clear();
+    window.sessionStorage.clear();
   });
 
   await page.route("**/api/v1/**", async (route) => {
@@ -116,6 +117,9 @@ test.beforeEach(async ({ page }) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
+        headers: {
+          "Set-Cookie": "tradelab_app_session=cookie-token; Path=/; HttpOnly; SameSite=Lax"
+        },
         body: JSON.stringify({
           account: {
             user_id: "user-registered",
@@ -136,6 +140,9 @@ test.beforeEach(async ({ page }) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
+        headers: {
+          "Set-Cookie": "tradelab_app_session=cookie-token; Path=/; HttpOnly; SameSite=Lax"
+        },
         body: JSON.stringify({
           account: {
             user_id: "user-registered",
@@ -146,6 +153,18 @@ test.beforeEach(async ({ page }) => {
             mode: "registered"
           }
         })
+      });
+      return;
+    }
+
+    if (url.endsWith("/api/v1/account/logout")) {
+      accountMode = "guest";
+      await route.fulfill({
+        status: 204,
+        headers: {
+          "Set-Cookie": "tradelab_app_session=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax"
+        },
+        body: ""
       });
       return;
     }
@@ -274,6 +293,8 @@ test("creates a demo session and renders the dashboard", async ({ page }) => {
   await expect(page.getByRole("heading", { name: /demo execution with/i })).toBeVisible();
   await expect(page.getByText("XRP/USDT").first()).toBeVisible();
   await expect(page.getByText(/feed fresh/i)).toBeVisible();
+  await expect.poll(() => page.evaluate(() => window.sessionStorage.getItem("tradelab.demo-session"))).not.toBeNull();
+  await expect.poll(() => page.evaluate(() => window.localStorage.getItem("tradelab.demo-session"))).toBeNull();
 });
 
 test("switches interval without clearing the portfolio panels", async ({ page }) => {
@@ -336,4 +357,25 @@ test("restores the registered account for a returning signed-in user", async ({ 
 
   await expect(page.getByText(/registered demo account/i)).toBeVisible();
   await expect(page.getByText(/mock google user/i)).toBeVisible();
+});
+
+test("logs out of a registered account and falls back to a guest session", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "tradelab.mock-auth",
+      JSON.stringify({
+        clerkUserID: "mock-google-user",
+        email: "google-user@google.mock.tradelab",
+        displayName: "Mock Google User"
+      })
+    );
+  });
+
+  await page.goto("/");
+
+  await expect(page.getByText(/registered demo account/i)).toBeVisible();
+  await page.getByRole("button", { name: /log out/i }).click();
+
+  await expect(page.getByText(/guest demo session/i)).toBeVisible();
+  await expect(page.getByText(/keep this sandbox beyond the guest session/i)).toBeVisible();
 });

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -97,6 +97,16 @@ export type CandleFeed = {
   meta: MarketDataMeta;
 };
 
+export class ApiError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+  }
+}
+
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
 
 function apiUrl(path: string) {
@@ -115,6 +125,11 @@ function authHeaders(token?: string) {
   return {
     Authorization: `Bearer ${token}`
   };
+}
+
+async function parseApiError(response: Response, fallback: string) {
+  const payload = await response.json().catch(() => ({ error: fallback }));
+  throw new ApiError(payload.error ?? fallback, response.status);
 }
 
 export async function createDemoSession(): Promise<DemoSession> {
@@ -171,11 +186,12 @@ export async function fetchCandles(marketSymbol: string, interval = "1h", limit 
 export async function fetchPortfolio(walletID: string, token: string): Promise<PortfolioSummary> {
   const response = await fetch(apiUrl(`/api/v1/portfolios/${walletID}`), {
     cache: "no-store",
+    credentials: "include",
     headers: authHeaders(token)
   });
 
   if (!response.ok) {
-    throw new Error("Failed to load portfolio");
+    await parseApiError(response, "Failed to load portfolio");
   }
 
   const data = await response.json();
@@ -185,10 +201,11 @@ export async function fetchPortfolio(walletID: string, token: string): Promise<P
 export async function fetchOrders(token: string): Promise<Order[]> {
   const response = await fetch(apiUrl("/api/v1/orders"), {
     cache: "no-store",
+    credentials: "include",
     headers: authHeaders(token)
   });
   if (!response.ok) {
-    throw new Error("Failed to load orders");
+    await parseApiError(response, "Failed to load orders");
   }
 
   const data = await response.json();
@@ -198,10 +215,11 @@ export async function fetchOrders(token: string): Promise<Order[]> {
 export async function fetchActivity(token: string): Promise<ActivityLog[]> {
   const response = await fetch(apiUrl("/api/v1/activity"), {
     cache: "no-store",
+    credentials: "include",
     headers: authHeaders(token)
   });
   if (!response.ok) {
-    throw new Error("Failed to load activity");
+    await parseApiError(response, "Failed to load activity");
   }
 
   const data = await response.json();
@@ -211,13 +229,14 @@ export async function fetchActivity(token: string): Promise<ActivityLog[]> {
 export async function placeMarketBuy(input: {
   marketSymbol: string;
   quoteAmount: number;
-  token: string;
+  token?: string | null;
 }) {
   const response = await fetch(apiUrl("/api/v1/orders"), {
     method: "POST",
+    credentials: "include",
     headers: {
       "Content-Type": "application/json",
-      ...authHeaders(input.token)
+      ...authHeaders(input.token ?? undefined)
     },
     body: JSON.stringify({
       market_symbol: input.marketSymbol,
@@ -226,8 +245,7 @@ export async function placeMarketBuy(input: {
   });
 
   if (!response.ok) {
-    const payload = await response.json().catch(() => ({ error: "Order failed" }));
-    throw new Error(payload.error ?? "Order failed");
+    await parseApiError(response, "Order failed");
   }
 
   return response.json();
@@ -236,12 +254,12 @@ export async function placeMarketBuy(input: {
 export async function bootstrapRegisteredAccount(token: string): Promise<RegisteredAccount> {
   const response = await fetch(apiUrl("/api/v1/account/bootstrap"), {
     method: "POST",
+    credentials: "include",
     headers: authHeaders(token)
   });
 
   if (!response.ok) {
-    const payload = await response.json().catch(() => ({ error: "Failed to bootstrap account" }));
-    throw new Error(payload.error ?? "Failed to bootstrap account");
+    await parseApiError(response, "Failed to bootstrap account");
   }
 
   const data = await response.json();
@@ -262,6 +280,7 @@ export async function upgradeGuestAccount(input: {
 }): Promise<RegisteredAccount> {
   const response = await fetch(apiUrl("/api/v1/account/upgrade"), {
     method: "POST",
+    credentials: "include",
     headers: {
       "Content-Type": "application/json",
       "X-TradeLab-Guest-Token": input.guestToken,
@@ -273,8 +292,7 @@ export async function upgradeGuestAccount(input: {
   });
 
   if (!response.ok) {
-    const payload = await response.json().catch(() => ({ error: "Failed to upgrade guest account" }));
-    throw new Error(payload.error ?? "Failed to upgrade guest account");
+    await parseApiError(response, "Failed to upgrade guest account");
   }
 
   const data = await response.json();
@@ -286,4 +304,15 @@ export async function upgradeGuestAccount(input: {
     displayName: data.account.display_name,
     mode: "registered"
   };
+}
+
+export async function logoutRegisteredAccount(): Promise<void> {
+  const response = await fetch(apiUrl("/api/v1/account/logout"), {
+    method: "POST",
+    credentials: "include"
+  });
+
+  if (!response.ok) {
+    await parseApiError(response, "Failed to log out");
+  }
 }

--- a/frontend/lib/tradelab-auth.tsx
+++ b/frontend/lib/tradelab-auth.tsx
@@ -10,6 +10,7 @@ import {
   useClerk,
   useUser
 } from "@clerk/nextjs";
+import { logoutRegisteredAccount } from "@/lib/api";
 
 type TradeLabAuthUser = {
   clerkUserID: string;
@@ -185,6 +186,7 @@ function MockAuthProvider({ children }: { children: React.ReactNode }) {
         setUser(nextUser);
       },
       signOut: async () => {
+        await logoutRegisteredAccount().catch(() => undefined);
         window.localStorage.removeItem(MOCK_STORAGE_KEY);
         setUser(null);
       }
@@ -216,6 +218,7 @@ function ClerkStateProvider({ children }: { children: React.ReactNode }) {
       getToken: async () => auth.getToken(),
       signInWithProvider: () => undefined,
       signOut: async () => {
+        await logoutRegisteredAccount().catch(() => undefined);
         await clerk.signOut();
       }
     }),

--- a/frontend/lib/use-account-session.ts
+++ b/frontend/lib/use-account-session.ts
@@ -3,6 +3,7 @@
 import { startTransition, useEffect, useMemo, useRef, useState } from "react";
 
 import {
+  ApiError,
   bootstrapRegisteredAccount,
   createDemoSession,
   fetchActivity,
@@ -39,7 +40,7 @@ type CoreDataState = {
   clearMessages: () => void;
   setErrorMessage: (message: string | null) => void;
   setSuccessMessage: (message: string | null) => void;
-  refreshCoreData: () => Promise<{ walletID: string; token: string } | null>;
+  refreshCoreData: () => Promise<{ walletID: string; token: string | null } | null>;
   upgradeGuestSession: (preserveGuestData: boolean) => Promise<void>;
   activeAccessToken: () => Promise<string | null>;
 };
@@ -69,7 +70,7 @@ export function useAccountSession(): CoreDataState {
       throw new Error("Demo session can only be created in the browser");
     }
 
-    const cachedValue = window.localStorage.getItem(DEMO_SESSION_STORAGE_KEY);
+    const cachedValue = window.sessionStorage.getItem(DEMO_SESSION_STORAGE_KEY);
     if (cachedValue) {
       try {
         const cachedSession = JSON.parse(cachedValue) as DemoSession;
@@ -77,30 +78,30 @@ export function useAccountSession(): CoreDataState {
           return cachedSession;
         }
       } catch {
-        window.localStorage.removeItem(DEMO_SESSION_STORAGE_KEY);
+        window.sessionStorage.removeItem(DEMO_SESSION_STORAGE_KEY);
       }
     }
 
     const nextSession = await createDemoSession();
-    window.localStorage.setItem(DEMO_SESSION_STORAGE_KEY, JSON.stringify(nextSession));
+    window.sessionStorage.setItem(DEMO_SESSION_STORAGE_KEY, JSON.stringify(nextSession));
     return nextSession;
   }
 
   function clearGuestSession() {
     if (typeof window !== "undefined") {
-      window.localStorage.removeItem(DEMO_SESSION_STORAGE_KEY);
+      window.sessionStorage.removeItem(DEMO_SESSION_STORAGE_KEY);
     }
     setGuestSession(null);
   }
 
-  async function loadCoreData(walletID: string, token: string) {
+  async function loadCoreData(walletID: string, token?: string | null) {
     setError(null);
 
     const [marketList, portfolioSummary, orderHistory, activityHistory] = await Promise.all([
       fetchMarkets(),
-      fetchPortfolio(walletID, token),
-      fetchOrders(token),
-      fetchActivity(token)
+      fetchPortfolio(walletID, token ?? ""),
+      fetchOrders(token ?? ""),
+      fetchActivity(token ?? "")
     ]);
 
     setMarkets(marketList);
@@ -117,9 +118,8 @@ export function useAccountSession(): CoreDataState {
 
     const account = await bootstrapRegisteredAccount(token);
     setRegisteredAccount(account);
-    setGuestSession(null);
-    await loadCoreData(account.walletID, token);
-    return { walletID: account.walletID, token };
+    await loadCoreData(account.walletID);
+    return { walletID: account.walletID, token: null };
   }
 
   async function activateGuestExperience() {
@@ -154,8 +154,14 @@ export function useAccountSession(): CoreDataState {
       };
 
       run()
-        .catch((loadError: Error) => {
+        .catch(async (loadError: Error) => {
           if (!cancelled) {
+            if (loadError instanceof ApiError && loadError.status === 401 && auth.status === "signed_in") {
+              await auth.signOut();
+              setError("Registered session expired. Please sign in again.");
+              return;
+            }
+
             setError(loadError.message);
           }
         })
@@ -191,18 +197,25 @@ export function useAccountSession(): CoreDataState {
 
   async function refreshCoreData() {
     if (registeredAccount) {
-      const token = await auth.getToken();
-      if (!token) {
-        throw new Error("Registered session token is unavailable");
-      }
-
-      await loadCoreData(registeredAccount.walletID, token);
-      return { walletID: registeredAccount.walletID, token };
+      await loadCoreData(registeredAccount.walletID);
+      return { walletID: registeredAccount.walletID, token: null };
     }
 
     if (guestSession) {
-      await loadCoreData(guestSession.walletID, guestSession.token);
-      return { walletID: guestSession.walletID, token: guestSession.token };
+      try {
+        await loadCoreData(guestSession.walletID, guestSession.token);
+        return { walletID: guestSession.walletID, token: guestSession.token };
+      } catch (refreshError) {
+        if (refreshError instanceof ApiError && refreshError.status === 401) {
+          const nextSession = await ensureGuestSession();
+          setGuestSession(nextSession);
+          await loadCoreData(nextSession.walletID, nextSession.token);
+          setSuccess("Guest session refreshed.");
+          return { walletID: nextSession.walletID, token: nextSession.token };
+        }
+
+        throw refreshError;
+      }
     }
 
     return null;
@@ -246,7 +259,7 @@ export function useAccountSession(): CoreDataState {
 
   async function activeAccessToken() {
     if (registeredAccount) {
-      return auth.getToken();
+      return null;
     }
 
     return guestSession?.token ?? null;

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- add TradeLab-managed registered app sessions with HttpOnly cookies, expiry, and revocation
- move guest session persistence to sessionStorage and remove JS-visible registered app tokens
- document security boundaries, logging redaction, and secret handling while expanding tests

## Testing
- go test ./...
- npm.cmd run test
- npm.cmd run build
- npm.cmd run test:e2e

Closes #46
Closes #47
Closes #48
Closes #49
Closes #50