### PR TITLE
Fix UUID migration types for Kubernetes deploys

### DIFF
--- a/backend/migrations/000008_add_app_sessions.up.sql
+++ b/backend/migrations/000008_add_app_sessions.up.sql
@@ -1,7 +1,7 @@
 CREATE TABLE app_sessions (
-    id TEXT PRIMARY KEY,
-    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    wallet_id TEXT NOT NULL REFERENCES wallets(id) ON DELETE CASCADE,
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    wallet_id UUID NOT NULL REFERENCES wallets(id) ON DELETE CASCADE,
     principal_kind TEXT NOT NULL,
     token_hash TEXT NOT NULL UNIQUE,
     idle_expires_at TIMESTAMPTZ NOT NULL,

--- a/backend/migrations/000009_add_strategies.up.sql
+++ b/backend/migrations/000009_add_strategies.up.sql
@@ -1,7 +1,7 @@
 CREATE TABLE strategies (
-    id TEXT PRIMARY KEY,
-    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    wallet_id TEXT NOT NULL REFERENCES wallets(id) ON DELETE CASCADE,
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    wallet_id UUID NOT NULL REFERENCES wallets(id) ON DELETE CASCADE,
     market_id UUID NOT NULL REFERENCES markets(id) ON DELETE CASCADE,
     status TEXT NOT NULL,
     config_json JSONB NOT NULL,
@@ -21,8 +21,8 @@ CREATE INDEX idx_strategies_wallet_status ON strategies(wallet_id, status);
 CREATE INDEX idx_strategies_claim ON strategies(status, evaluation_claimed_at);
 
 CREATE TABLE strategy_runs (
-    id TEXT PRIMARY KEY,
-    strategy_id TEXT NOT NULL REFERENCES strategies(id) ON DELETE CASCADE,
+    id UUID PRIMARY KEY,
+    strategy_id UUID NOT NULL REFERENCES strategies(id) ON DELETE CASCADE,
     decision TEXT NOT NULL,
     outcome TEXT NOT NULL,
     reason TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- fix UUID type mismatches in app session migration
- fix UUID type mismatches in strategy migrations
- unblock backend startup in Kubernetes by allowing migrations to apply

## Testing
- go test ./...

This addresses the deployment blocker found on the k3s cluster.