### PR TITLE
Add manual backfill for master image publication

### DIFF
--- a/.github/workflows/publish-master-images.yml
+++ b/.github/workflows/publish-master-images.yml
@@ -6,6 +6,13 @@ on:
       - master
     paths-ignore:
       - deploy/infrastructure/applications/tradelab-dev.yaml
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: Git ref to publish for development backfill
+        required: true
+        default: master
+        type: string
 
 permissions:
   contents: write
@@ -22,18 +29,21 @@ jobs:
     outputs:
       short_sha: ${{ steps.meta.outputs.short_sha }}
       full_sha: ${{ steps.meta.outputs.full_sha }}
+      source_ref: ${{ steps.meta.outputs.source_ref }}
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.source_ref || github.sha }}
 
       - name: Compute image metadata
         id: meta
         shell: bash
         run: |
           short_sha="$(git rev-parse --short=12 HEAD)"
+          source_ref="${{ github.event_name == 'workflow_dispatch' && inputs.source_ref || github.sha }}"
+          echo "source_ref=$source_ref" >> "$GITHUB_OUTPUT"
           echo "short_sha=$short_sha" >> "$GITHUB_OUTPUT"
           echo "full_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 

--- a/docs/ai-metadata.json
+++ b/docs/ai-metadata.json
@@ -87,7 +87,7 @@
   "constraints": {
     "code_language": "English",
     "chat_language": "German",
-    "delivery_model": "Feature branches -> PR CI -> merge to master -> publish master images for dev -> release",
+    "delivery_model": "Feature branches -> PR CI -> merge to master -> publish master images for dev -> manual backfill via workflow_dispatch when needed -> release",
     "merge_strategy": "squash merge",
     "demo_only": true,
     "live_trading": false,
@@ -166,14 +166,15 @@
       },
       {
         "workflow": "Publish Master Images",
-        "trigger": ["push:master"],
+        "trigger": ["push:master", "workflow_dispatch"],
         "conditions": [
           "skip commits that only update deploy/infrastructure/applications/tradelab-dev.yaml"
         ],
         "jobs_order": [
           "Build and publish backend/frontend master images",
           "Update tradelab-dev Argo application to source commit SHA plus matching immutable master image tags"
-        ]
+        ],
+        "manual_backfill": "Dispatch the workflow with source_ref=master when the current merged master state needs development images and Argo target updates backfilled"
       },
       {
         "workflow": "Release",
@@ -805,6 +806,15 @@
           "update docs/system-operations.md",
           "update docs/developer-guide.md",
           "update docs/ai-metadata.json"
+        ]
+      },
+      {
+        "scenario": "The development cluster did not receive images for the current merged master state",
+        "followups": [
+          "manually dispatch Publish Master Images with source_ref=master",
+          "verify GHCR now contains the expected master-<shortsha> images",
+          "verify deploy/infrastructure/applications/tradelab-dev.yaml points to the matching source commit and immutable image tags",
+          "verify Argo CD syncs the updated development application"
         ]
       },
       {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -127,6 +127,7 @@ Development image policy:
 - the overlay defaults to the mutable `master` tag for direct manual rendering
 - the Argo CD development application overrides both images to immutable `master-<shortsha>` tags
 - the same Argo application pins `targetRevision` to the exact source commit that produced those images
+- if the master-image workflow was introduced after the current `master` state landed or a run was missed, operators can manually dispatch `Publish Master Images` with `source_ref=master` to backfill the immutable development images and Argo target update
 
 ### Kubernetes production parameters
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -219,6 +219,8 @@ It then commits the exact deployed development revision back into [tradelab-dev.
 - the Argo CD `targetRevision` to the source commit SHA
 - backend and frontend image overrides to the matching immutable `master-<shortsha>` tags
 
+If the workflow was introduced after the current merged `master` state or a publish run needs to be repeated, manually dispatch `Publish Master Images` with `source_ref=master`. That backfills GHCR with the missing immutable dev images and updates `tradelab-dev.yaml` to the matching source commit.
+
 This is the expected delivery chain for normal feature work:
 
 `feature branch -> pull request -> CI -> auto-merge -> master -> publish master images and update Argo dev -> manual release -> manual production promotion`

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -15,9 +15,10 @@ The release workflow is intentionally manual and is triggered through GitHub Act
 Recommended operator flow:
 
 1. merge reviewed work into `master`
-2. trigger the `Release` workflow from `master`
-3. confirm the GitHub Release and immutable images were published
-4. trigger `Promote Production` when production should move to the newest official release
+2. if the development publish step for the current `master` state was missed, manually dispatch `Publish Master Images` with `source_ref=master`
+3. trigger the `Release` workflow from `master`
+4. confirm the GitHub Release and immutable images were published
+5. trigger `Promote Production` when production should move to the newest official release
 
 ## Release stages
 

--- a/docs/system-operations.md
+++ b/docs/system-operations.md
@@ -181,6 +181,8 @@ This means the effective repository delivery path is:
 
 `pull request -> CI -> auto-merge into master -> master image publication and Argo dev update -> manual release verification/build/publish/package -> GitHub release -> manual production promotion`
 
+If a merged `master` state needs to be backfilled because the workflow was added later or a publish run was missed, operators should manually dispatch `Publish Master Images` with `source_ref=master` before troubleshooting Argo drift.
+
 For a release-focused view of published artifacts and release meaning, see [release-process.md](release-process.md).
 
 ## Health and failure surfaces


### PR DESCRIPTION
## Summary\n- add a workflow_dispatch backfill path to Publish Master Images\n- document how to republish the current merged master state when a run was missed\n- update ai metadata so the backfill path is part of the delivery contract\n\nCloses #87