### PR TITLE
Fix activity reload and resilient dashboard refresh

### DIFF
--- a/backend/internal/store/postgres/postgres.go
+++ b/backend/internal/store/postgres/postgres.go
@@ -744,8 +744,8 @@ func (r *PortfolioRepository) ListActivityByWallet(ctx context.Context, walletID
 		LEFT JOIN markets order_markets ON order_markets.id = orders.market_id
 		LEFT JOIN strategies ON strategies.id = activity_logs.strategy_id
 		LEFT JOIN markets strategy_markets ON strategy_markets.id = strategies.market_id
-		WHERE wallet_id = $1
-		ORDER BY created_at DESC
+		WHERE activity_logs.wallet_id = $1
+		ORDER BY activity_logs.created_at DESC
 	`
 
 	var rows *sql.Rows

--- a/backend/internal/store/postgres/postgres_test.go
+++ b/backend/internal/store/postgres/postgres_test.go
@@ -275,3 +275,45 @@ func TestListByWalletCastsStrategyIDToText(t *testing.T) {
 		t.Fatalf("unmet expectations: %v", err)
 	}
 }
+
+func TestListActivityByWalletQualifiesJoinedColumns(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewPortfolioRepository(db)
+	rows := sqlmock.NewRows([]string{
+		"id", "wallet_id", "market_symbol", "log_type", "title", "message", "created_at",
+	}).AddRow(
+		"log-1", "wallet-1", "XRP/USDT", "trade", "Demo buy recorded", "Bought 10 XRP.", time.Date(2026, 3, 30, 8, 15, 0, 0, time.UTC),
+	)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT activity_logs.id, activity_logs.wallet_id, COALESCE(order_markets.symbol, strategy_markets.symbol, ''), activity_logs.log_type, activity_logs.title, activity_logs.message, activity_logs.created_at
+		FROM activity_logs
+		LEFT JOIN orders ON orders.id = activity_logs.order_id
+		LEFT JOIN markets order_markets ON order_markets.id = orders.market_id
+		LEFT JOIN strategies ON strategies.id = activity_logs.strategy_id
+		LEFT JOIN markets strategy_markets ON strategy_markets.id = strategies.market_id
+		WHERE activity_logs.wallet_id = $1
+		ORDER BY activity_logs.created_at DESC
+		LIMIT $2
+	`)).WithArgs("wallet-1", 10).WillReturnRows(rows)
+
+	activity, err := repo.ListActivityByWallet(context.Background(), "wallet-1", 10)
+	if err != nil {
+		t.Fatalf("list activity by wallet: %v", err)
+	}
+	if len(activity) != 1 {
+		t.Fatalf("expected one activity log, got %d", len(activity))
+	}
+	if activity[0].Title != "Demo buy recorded" {
+		t.Fatalf("expected activity title to round-trip, got %q", activity[0].Title)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}

--- a/docs/ai-metadata.json
+++ b/docs/ai-metadata.json
@@ -344,6 +344,24 @@
     },
     "reproducibility_policy": {
       "rule": "Prefer repository-tracked, reproducible fixes through code, manifests, workflows, and documentation over one-off manual cluster or environment changes."
+    },
+    "ticket_execution_policy": {
+      "rule": "Every implementation should map to a concrete GitHub issue or an explicitly documented PR slice before code changes begin."
+    },
+    "ticket_planning_policy": {
+      "rule": "Before implementation, record the intended scope, root cause, acceptance criteria, and PR grouping in the issue body or a planning comment."
+    },
+    "ticket_progress_policy": {
+      "rule": "Track ticket progress through body plus comments: the body holds stable problem and acceptance context, while comments record phase transitions for the active PR slice."
+    },
+    "ticket_progress_states": {
+      "ordered_states": [
+        "planning_started",
+        "plan_locked",
+        "implementation_started",
+        "verification_complete",
+        "merged_closed"
+      ]
     }
   },
   "configuration": {

--- a/frontend/__tests__/home.test.tsx
+++ b/frontend/__tests__/home.test.tsx
@@ -6,6 +6,7 @@ type FetchScenario = {
   candleMode?: "fresh" | "stale";
   failCandles?: boolean;
   failOrder?: boolean;
+  failActivityOnRefresh?: boolean;
 };
 
 function installFetchMock(scenario: FetchScenario = {}) {
@@ -236,6 +237,11 @@ function installFetchMock(scenario: FetchScenario = {}) {
 
     if (url.includes("/api/v1/activity")) {
       record("activity");
+
+      if (scenario.failActivityOnRefresh && orderStateIndex > 0) {
+        return Promise.resolve(new Response(JSON.stringify({ error: "Failed to load activity" }), { status: 500 }));
+      }
+
       return Promise.resolve(new Response(JSON.stringify({ activity: orderResponses[orderStateIndex].activity })));
     }
 
@@ -345,6 +351,26 @@ describe("Hero", () => {
     expect(fetchCounts.portfolio).toBe(2);
     expect(fetchCounts.orders).toBe(2);
     expect(fetchCounts.activity).toBe(2);
+  });
+
+  it("keeps balances visible when activity refresh fails after a demo buy", async () => {
+    installFetchMock({ failActivityOnRefresh: true });
+
+    render(<Hero />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /run demo buy/i })).toBeEnabled();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /run demo buy/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/demo buy executed for xrp\/usdt/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/\$10,025.00/)).toBeInTheDocument();
+    expect(screen.getByText(/failed to load activity/i)).toBeInTheDocument();
+    expect(screen.getByText(/\$9,875.00/)).toBeInTheDocument();
   });
 
   it("keeps non-chart panels visible when candle loading fails", async () => {

--- a/frontend/components/market-dashboard.tsx
+++ b/frontend/components/market-dashboard.tsx
@@ -94,7 +94,7 @@ export function MarketDashboard({ detailOnly = false, initialMarket = "XRP/USDT"
   const auth = useTradeLabAuth();
   const buildInfo = resolveBuildInfo();
   const {
-    guestSession, registeredAccount, markets, portfolio, orders, activity, strategies, accountingMode, isLoading, isUpgrading,
+    guestSession, registeredAccount, markets, portfolio, orders, activity, activityError, strategies, accountingMode, isLoading, isUpgrading,
     showUpgradePrompt, error, success, activeWalletID, accountModeLabel, shouldShowAuthValuePrompt,
     clearMessages, setErrorMessage, setSuccessMessage, setAccountingMode, refreshCoreData, upgradeGuestSession, activeAccessToken
   } = useAccountSession();
@@ -431,12 +431,13 @@ export function MarketDashboard({ detailOnly = false, initialMarket = "XRP/USDT"
             <section className="rounded-[32px] border border-[var(--line)] bg-[var(--surface)] p-5 backdrop-blur">
               <p className="font-[var(--font-mono)] text-xs uppercase tracking-[0.28em] text-[var(--muted)]">{detailOnly ? "Selected market activity" : "Activity log"}</p>
               <div className="mt-5 grid gap-3">
+                {activityError ? <div className="rounded-2xl border border-[rgba(255,107,120,0.35)] bg-[rgba(255,107,120,0.08)] px-4 py-4 text-sm text-[var(--accent-hot)]">{activityError}</div> : null}
                 {visibleActivity.length ? visibleActivity.map((item) => (
                   <div key={item.id} className="rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.45)] px-4 py-4">
                     <div className="flex items-center justify-between gap-4"><span className="text-lg font-semibold">{item.title}</span><span className="text-sm uppercase text-[var(--accent-hot)]">{item.logType}</span></div>
                     <p className="mt-2 text-sm text-[var(--muted)]">{item.message}</p>
                   </div>
-                )) : <div className="rounded-2xl border border-dashed border-[var(--line)] px-4 py-6 text-sm text-[var(--muted)]">Activity will populate as soon as trades are executed for this scope.</div>}
+                )) : activityError ? null : <div className="rounded-2xl border border-dashed border-[var(--line)] px-4 py-6 text-sm text-[var(--muted)]">Activity will populate as soon as trades are executed for this scope.</div>}
               </div>
             </section>
           </div>

--- a/frontend/e2e/home.spec.ts
+++ b/frontend/e2e/home.spec.ts
@@ -508,6 +508,35 @@ test("executes a demo buy and refreshes portfolio metrics", async ({ page }) => 
   await expect(page.getByText(/\$10,025.00/)).toBeVisible();
 });
 
+test("keeps balances visible when the activity refresh fails after a demo buy", async ({ page }) => {
+  let activityRequests = 0;
+
+  await page.route("**/api/v1/activity", async (route) => {
+    activityRequests += 1;
+    if (activityRequests > 1) {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Failed to load activity" })
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ activity: portfolioState(0).activity })
+    });
+  });
+
+  await page.goto("/");
+  await page.getByRole("button", { name: /run demo buy/i }).click();
+
+  await expect(page.getByText(/demo buy executed for xrp\/usdt/i)).toBeVisible();
+  await expect(page.getByText(/\$10,025.00/)).toBeVisible();
+  await expect(page.getByText(/failed to load activity/i)).toBeVisible();
+});
+
 test("executes a partial sell from the market detail page", async ({ page }) => {
   await page.goto("/markets/XRP%2FUSDT");
   await page.locator("input").nth(1).fill("50");

--- a/frontend/lib/use-account-session.ts
+++ b/frontend/lib/use-account-session.ts
@@ -33,6 +33,7 @@ type CoreDataState = {
   portfolio: PortfolioSummary | null;
   orders: Order[];
   activity: ActivityLog[];
+  activityError: string | null;
   strategies: Strategy[];
   accountingMode: AccountingMode;
   isLoading: boolean;
@@ -63,6 +64,7 @@ export function useAccountSession(): CoreDataState {
   const [portfolio, setPortfolio] = useState<PortfolioSummary | null>(null);
   const [orders, setOrders] = useState<Order[]>([]);
   const [activity, setActivity] = useState<ActivityLog[]>([]);
+  const [activityError, setActivityError] = useState<string | null>(null);
   const [strategies, setStrategies] = useState<Strategy[]>([]);
   const [accountingMode, setAccountingModeState] = useState<AccountingMode>("average_cost");
   const [isLoading, setIsLoading] = useState(true);
@@ -115,22 +117,66 @@ export function useAccountSession(): CoreDataState {
     }
   }, []);
 
-  async function loadCoreData(walletID: string, token?: string | null) {
-    setError(null);
+  function resolveErrorMessage(reason: unknown, fallback: string) {
+    if (reason instanceof Error && reason.message.trim() !== "") {
+      return reason.message;
+    }
 
-    const [marketList, portfolioSummary, orderHistory, activityHistory, strategyList] = await Promise.all([
+    return fallback;
+  }
+
+  async function loadCoreData(walletID: string, token?: string | null) {
+    const results = await Promise.allSettled([
       fetchMarkets(),
       fetchPortfolio(walletID, token ?? "", accountingMode),
       fetchOrders(token ?? "", { accountingMode }),
       fetchActivity(token ?? ""),
       fetchStrategies(token ?? "")
     ]);
+    const [marketList, portfolioSummary, orderHistory, activityHistory, strategyList] = results;
 
-    setMarkets(marketList);
-    setPortfolio(portfolioSummary);
-    setOrders(orderHistory);
-    setActivity(activityHistory);
-    setStrategies(strategyList);
+    const authFailure = results.find(
+      (result): result is PromiseRejectedResult =>
+        result.status === "rejected" && result.reason instanceof ApiError && result.reason.status === 401
+    );
+    if (authFailure) {
+      throw authFailure.reason;
+    }
+
+    let nextError: string | null = null;
+
+    if (marketList.status === "fulfilled") {
+      setMarkets(marketList.value);
+    } else {
+      nextError ??= resolveErrorMessage(marketList.reason, "Failed to load markets");
+    }
+
+    if (portfolioSummary.status === "fulfilled") {
+      setPortfolio(portfolioSummary.value);
+    } else {
+      nextError ??= resolveErrorMessage(portfolioSummary.reason, "Failed to load portfolio");
+    }
+
+    if (orderHistory.status === "fulfilled") {
+      setOrders(orderHistory.value);
+    } else {
+      nextError ??= resolveErrorMessage(orderHistory.reason, "Failed to load orders");
+    }
+
+    if (activityHistory.status === "fulfilled") {
+      setActivity(activityHistory.value);
+      setActivityError(null);
+    } else {
+      setActivityError(resolveErrorMessage(activityHistory.reason, "Failed to load activity"));
+    }
+
+    if (strategyList.status === "fulfilled") {
+      setStrategies(strategyList.value);
+    } else {
+      nextError ??= resolveErrorMessage(strategyList.reason, "Failed to load strategies");
+    }
+
+    setError(nextError);
   }
 
   async function bootstrapRegistered() {
@@ -325,6 +371,7 @@ export function useAccountSession(): CoreDataState {
       portfolio,
       orders,
       activity,
+      activityError,
       strategies,
       accountingMode,
       isLoading,
@@ -345,6 +392,7 @@ export function useAccountSession(): CoreDataState {
     }),
     [
       activity,
+      activityError,
       accountingMode,
       activeWalletID,
       accountModeLabel,


### PR DESCRIPTION
## Summary
- fixes the ambiguous activity query behind `#91`
- makes dashboard reloads resilient to partial read failures for `#94`
- records the default ticket progress workflow in `docs/ai-metadata.json`

## Changes
- qualify `activity_logs.wallet_id` and `activity_logs.created_at` in `ListActivityByWallet`
- add a store regression test for joined activity reads
- switch dashboard core data loading to panel-oriented `Promise.allSettled(...)`
- keep successful portfolio, balances, and orders visible if activity fails separately
- render an activity-panel-specific error state instead of blanking the whole dashboard
- add frontend unit and Playwright coverage for the post-buy partial-failure path
- codify ticket planning/progress defaults in `docs/ai-metadata.json`

## Verification
- `go test ./...`
- `npm.cmd run test`
- `npm.cmd run build`
- `npm.cmd run test:e2e`

Closes #91
Closes #94