### PR TITLE
Fix protected-branch-safe dev image promotion

### DIFF
--- a/.github/workflows/publish-master-images.yml
+++ b/.github/workflows/publish-master-images.yml
@@ -17,6 +17,7 @@ on:
 permissions:
   contents: write
   packages: write
+  pull-requests: write
 
 concurrency:
   group: publish-master-images
@@ -158,15 +159,23 @@ jobs:
 
           app_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
-      - name: Commit development target update
-        shell: bash
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add deploy/infrastructure/applications/tradelab-dev.yaml
-          if git diff --cached --quiet; then
-            echo "Development application already points at this master revision."
-            exit 0
-          fi
-          git commit -m "Update development Argo target to ${{ needs.publish-master-images.outputs.short_sha }}"
-          git push origin HEAD:master
+      - name: Create development target update pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Update development Argo target to ${{ needs.publish-master-images.outputs.short_sha }}
+          title: Update development Argo target to ${{ needs.publish-master-images.outputs.short_sha }}
+          body: |
+            ## Summary
+            - update `tradelab-dev` to the newly published `master-${{ needs.publish-master-images.outputs.short_sha }}` images
+            - pin the Argo application source revision to `${{ needs.publish-master-images.outputs.full_sha }}`
+
+            ## Source
+            - workflow: `Publish Master Images`
+            - source ref: `${{ needs.publish-master-images.outputs.source_ref }}`
+            - source commit: `${{ needs.publish-master-images.outputs.full_sha }}`
+          branch: automation/update-tradelab-dev-target
+          branch-suffix: short-commit-hash
+          delete-branch: true
+          add-paths: |
+            deploy/infrastructure/applications/tradelab-dev.yaml

--- a/docs/ai-metadata.json
+++ b/docs/ai-metadata.json
@@ -87,7 +87,7 @@
   "constraints": {
     "code_language": "English",
     "chat_language": "German",
-    "delivery_model": "Feature branches -> PR CI -> merge to master -> publish master images for dev -> manual backfill via workflow_dispatch when needed -> release",
+    "delivery_model": "Feature branches -> PR CI -> merge to master -> publish master images for dev -> bot PR updates Argo dev target -> CI -> merge -> manual backfill via workflow_dispatch when needed -> release",
     "merge_strategy": "squash merge",
     "demo_only": true,
     "live_trading": false,
@@ -172,9 +172,9 @@
         ],
         "jobs_order": [
           "Build and publish backend/frontend master images",
-          "Update tradelab-dev Argo application to source commit SHA plus matching immutable master image tags"
+          "Create a bot-authored pull request that updates tradelab-dev to the source commit SHA plus matching immutable master image tags"
         ],
-        "manual_backfill": "Dispatch the workflow with source_ref=master when the current merged master state needs development images and Argo target updates backfilled"
+        "manual_backfill": "Dispatch the workflow with source_ref=master when the current merged master state needs development images and a matching development-target update pull request backfilled"
       },
       {
         "workflow": "Release",
@@ -831,7 +831,8 @@
         "followups": [
           "manually dispatch Publish Master Images with source_ref=master",
           "verify GHCR now contains the expected master-<shortsha> images",
-          "verify deploy/infrastructure/applications/tradelab-dev.yaml points to the matching source commit and immutable image tags",
+          "verify the generated development-target pull request updated deploy/infrastructure/applications/tradelab-dev.yaml to the matching source commit and immutable image tags",
+          "verify the generated development-target pull request merged successfully",
           "verify Argo CD syncs the updated development application"
         ]
       },

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -127,7 +127,8 @@ Development image policy:
 - the overlay defaults to the mutable `master` tag for direct manual rendering
 - the Argo CD development application overrides both images to immutable `master-<shortsha>` tags
 - the same Argo application pins `targetRevision` to the exact source commit that produced those images
-- if the master-image workflow was introduced after the current `master` state landed or a run was missed, operators can manually dispatch `Publish Master Images` with `source_ref=master` to backfill the immutable development images and Argo target update
+- the master-image workflow updates the development Argo target through a bot-authored pull request so protected-branch rules remain intact
+- if the master-image workflow was introduced after the current `master` state landed or a run was missed, operators can manually dispatch `Publish Master Images` with `source_ref=master` to backfill the immutable development images and open the matching Argo-target update PR
 
 ### Kubernetes production parameters
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -214,16 +214,18 @@ Every merge to `master` builds and publishes backend and frontend development im
 - `master`
 - `master-<shortsha>`
 
-It then commits the exact deployed development revision back into [tradelab-dev.yaml](../deploy/infrastructure/applications/tradelab-dev.yaml), setting:
+It then opens a bot-authored pull request that updates [tradelab-dev.yaml](../deploy/infrastructure/applications/tradelab-dev.yaml), setting:
 
 - the Argo CD `targetRevision` to the source commit SHA
 - backend and frontend image overrides to the matching immutable `master-<shortsha>` tags
 
-If the workflow was introduced after the current merged `master` state or a publish run needs to be repeated, manually dispatch `Publish Master Images` with `source_ref=master`. That backfills GHCR with the missing immutable dev images and updates `tradelab-dev.yaml` to the matching source commit.
+That follow-up PR runs through the normal repository CI and is merged through the existing auto-merge path, so protected-branch rules stay intact.
+
+If the workflow was introduced after the current merged `master` state or a publish run needs to be repeated, manually dispatch `Publish Master Images` with `source_ref=master`. That backfills GHCR with the missing immutable dev images and opens the matching development-target update PR.
 
 This is the expected delivery chain for normal feature work:
 
-`feature branch -> pull request -> CI -> auto-merge -> master -> publish master images and update Argo dev -> manual release -> manual production promotion`
+`feature branch -> pull request -> CI -> auto-merge -> master -> publish master images -> bot PR updates Argo dev target -> CI -> auto-merge -> manual release -> manual production promotion`
 
 ## Contribution expectations
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -8,7 +8,7 @@ This document explains what a TradeLab release means, how it is triggered, and h
 
 TradeLab releases are driven by the GitHub workflow chain:
 
-`pull request -> CI -> auto-merge -> master -> publish master images for development -> manual release workflow`
+`pull request -> CI -> auto-merge -> master -> publish master images for development -> bot PR updates dev target -> CI -> auto-merge -> manual release workflow`
 
 The release workflow is intentionally manual and is triggered through GitHub Actions `workflow_dispatch`.
 
@@ -16,9 +16,10 @@ Recommended operator flow:
 
 1. merge reviewed work into `master`
 2. if the development publish step for the current `master` state was missed, manually dispatch `Publish Master Images` with `source_ref=master`
-3. trigger the `Release` workflow from `master`
-4. confirm the GitHub Release and immutable images were published
-5. trigger `Promote Production` when production should move to the newest official release
+3. verify that the bot-authored development-target PR was created and merged
+4. trigger the `Release` workflow from `master`
+5. confirm the GitHub Release and immutable images were published
+6. trigger `Promote Production` when production should move to the newest official release
 
 ## Release stages
 

--- a/docs/system-operations.md
+++ b/docs/system-operations.md
@@ -179,9 +179,9 @@ It:
 
 This means the effective repository delivery path is:
 
-`pull request -> CI -> auto-merge into master -> master image publication and Argo dev update -> manual release verification/build/publish/package -> GitHub release -> manual production promotion`
+`pull request -> CI -> auto-merge into master -> master image publication -> bot PR updates Argo dev target -> CI -> auto-merge -> manual release verification/build/publish/package -> GitHub release -> manual production promotion`
 
-If a merged `master` state needs to be backfilled because the workflow was added later or a publish run was missed, operators should manually dispatch `Publish Master Images` with `source_ref=master` before troubleshooting Argo drift.
+If a merged `master` state needs to be backfilled because the workflow was added later or a publish run was missed, operators should manually dispatch `Publish Master Images` with `source_ref=master`, then verify that the generated development-target PR merged before troubleshooting Argo drift.
 
 For a release-focused view of published artifacts and release meaning, see [release-process.md](release-process.md).
 


### PR DESCRIPTION
## Summary
- replace the direct protected-branch push in `Publish Master Images`
- update the development Argo target through a bot-authored pull request
- document the corrected GitOps chain in the repo docs and metadata

## Verification
- `git diff --check`
- `node` JSON parse for `docs/ai-metadata.json`

Closes #98