### PR TITLE
Fix runtime auth entrypoint availability

### DIFF
--- a/deploy/kubernetes/overlays/development/kustomization.yaml
+++ b/deploy/kubernetes/overlays/development/kustomization.yaml
@@ -17,3 +17,5 @@ images:
 
 patches:
   - path: patch-ingress.yaml
+  - path: patch-backend-configmap.yaml
+  - path: patch-frontend-configmap.yaml

--- a/deploy/kubernetes/overlays/development/patch-backend-configmap.yaml
+++ b/deploy/kubernetes/overlays/development/patch-backend-configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tradelab-backend-config
+data:
+  TRADESLAB_AUTH_MOCK_MODE: "true"

--- a/deploy/kubernetes/overlays/development/patch-frontend-configmap.yaml
+++ b/deploy/kubernetes/overlays/development/patch-frontend-configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tradelab-frontend-config
+data:
+  NEXT_PUBLIC_AUTH_MOCK_MODE: "true"

--- a/docs/ai-metadata.json
+++ b/docs/ai-metadata.json
@@ -384,6 +384,7 @@
       "NEXT_PUBLIC_BUILD_BRANCH",
       "NEXT_PUBLIC_BUILD_COMMIT"
     ],
+    "frontend_auth_runtime_resolution": "frontend/app/layout.tsx resolves auth availability from runtime env and passes it into the client auth provider so deployed Clerk or mock-auth settings can change the visible sign-in surface without rebuilding the frontend image",
     "kubernetes_development_secret_keys": [
       "POSTGRES_DB",
       "POSTGRES_USER",

--- a/docs/clerk-architecture.md
+++ b/docs/clerk-architecture.md
@@ -17,8 +17,8 @@ Clerk is responsible for authenticating a user. The TradeLab backend remains res
 
 The Next.js frontend now:
 
-- renders Clerk UI for signup, login, account, and logout flows when `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` is configured
-- supports a local and CI-friendly mock auth mode through `NEXT_PUBLIC_AUTH_MOCK_MODE=true`
+- renders Clerk UI for signup, login, account, and logout flows when `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` is configured at runtime
+- supports a local, CI, and development-cluster-friendly mock auth mode through `NEXT_PUBLIC_AUTH_MOCK_MODE=true`
 - distinguish clearly between guest mode and registered mode
 - attach identity context when calling registered-account backend flows
 - continue to support the current guest bootstrap path for first-time use

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -78,12 +78,13 @@ These environment variables affect the Next.js frontend runtime and rewrites.
 | `TRADESLAB_API_PROXY_TARGET` | optional | before `npm run dev` or `npm run start` if the backend is not available at the default local address | `http://localhost:8080` | frontend rewrite target for `/api/*` requests |
 | `NEXT_PUBLIC_API_BASE_URL` | optional | before frontend startup only if you intentionally want browser calls to go directly to another API origin instead of using the rewrite path | empty string | frontend fetch client in the browser |
 | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | optional | before frontend startup when you want the real Clerk UI and token flow in the browser | empty | frontend Clerk provider |
-| `NEXT_PUBLIC_AUTH_MOCK_MODE` | optional | before frontend startup in local or CI runs when mock Google/Apple auth should replace live Clerk configuration | `false` | frontend auth provider wrapper |
+| `NEXT_PUBLIC_AUTH_MOCK_MODE` | optional | before frontend startup in local, CI, or development-cluster runs when mock Google/Apple auth should replace live Clerk configuration | `false` | frontend auth provider wrapper |
 
 Security notes:
 
 - `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` is frontend-safe
 - Clerk secret material must stay server-side and must not be committed or exposed through browser env vars
+- the Next.js app now resolves auth availability from server-rendered runtime env, so Kubernetes-injected frontend env vars can change the visible auth surface without rebuilding the image
 - `TRADESLAB_AUTH_MOCK_MODE` and `NEXT_PUBLIC_AUTH_MOCK_MODE` are development and CI switches only and must not be enabled in production manifests
 
 Recommended local default:

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -58,7 +58,7 @@ Before starting local services, review these only if you are not using the defau
 - `TRADESLAB_API_PROXY_TARGET` before frontend startup
 - `NEXT_PUBLIC_API_BASE_URL` before frontend startup if you want direct browser-to-API calls
 - `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` before frontend startup when using real Clerk UI
-- `NEXT_PUBLIC_AUTH_MOCK_MODE` before frontend startup when local or CI auth mocking should replace live Clerk UI
+- `NEXT_PUBLIC_AUTH_MOCK_MODE` before frontend startup when local, CI, or development-cluster auth mocking should replace live Clerk UI
 
 The full environment and deployment parameter reference lives in [deployment.md](deployment.md).
 
@@ -143,6 +143,7 @@ kubectl kustomize deploy/kubernetes/overlays/production-external-secrets
 - `frontend/components`: UI components, including the overview dashboard, focused market detail screen, and automation card
 - `frontend/lib`: API client code and shared helpers
 - `frontend/lib/tradelab-auth.tsx`: auth provider boundary for guest, mock, and Clerk-backed registered modes
+- `frontend/app/layout.tsx`: server-runtime auth config handoff so Clerk or mock auth can be switched through deployed env vars without rebuilding the frontend image
 - `frontend/lib/use-account-session.ts`: guest-plus-registered account orchestration plus guest session refresh logic
 - `frontend/__tests__`: component and workflow tests
 - `frontend/scripts`: utility scripts, including documentation screenshot generation

--- a/docs/system-operations.md
+++ b/docs/system-operations.md
@@ -66,6 +66,7 @@ Important frontend configuration includes:
 - `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`
 - `NEXT_PUBLIC_AUTH_MOCK_MODE`
 - any same-origin or proxy alignment needed for local/runtime routing
+- the frontend auth surface is resolved from runtime env on the Next.js server, so deployed env changes can enable Clerk or mock auth without rebuilding the frontend image
 
 ### Secrets
 

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Metadata } from "next";
 import { Space_Grotesk, IBM_Plex_Mono } from "next/font/google";
-import { TradeLabAuthProvider } from "@/lib/tradelab-auth";
+import { TradeLabAuthProvider, type TradeLabAuthRuntimeConfig } from "@/lib/tradelab-auth";
 import "./globals.css";
 
 const displayFont = Space_Grotesk({
@@ -20,15 +20,24 @@ export const metadata: Metadata = {
   description: "A multi-asset paper trading platform for strategy testing and automated demo execution."
 };
 
+function resolveAuthRuntimeConfig(): TradeLabAuthRuntimeConfig {
+  return {
+    mockMode: process.env.NEXT_PUBLIC_AUTH_MOCK_MODE === "true",
+    clerkPublishableKey: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ?? null
+  };
+}
+
 export default function RootLayout({
   children
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const authConfig = resolveAuthRuntimeConfig();
+
   return (
     <html lang="en">
       <body className={`${displayFont.variable} ${monoFont.variable}`}>
-        <TradeLabAuthProvider>{children}</TradeLabAuthProvider>
+        <TradeLabAuthProvider config={authConfig}>{children}</TradeLabAuthProvider>
       </body>
     </html>
   );

--- a/frontend/lib/tradelab-auth.tsx
+++ b/frontend/lib/tradelab-auth.tsx
@@ -27,8 +27,11 @@ type TradeLabAuthContextValue = {
   signOut: () => Promise<void>;
 };
 
-const AUTH_MOCK_MODE = process.env.NEXT_PUBLIC_AUTH_MOCK_MODE === "true";
-const CLERK_PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+export type TradeLabAuthRuntimeConfig = {
+  mockMode: boolean;
+  clerkPublishableKey: string | null;
+};
+
 const MOCK_STORAGE_KEY = "tradelab.mock-auth";
 
 const TradeLabAuthContext = createContext<TradeLabAuthContextValue>({
@@ -41,14 +44,20 @@ const TradeLabAuthContext = createContext<TradeLabAuthContextValue>({
   signOut: async () => undefined
 });
 
-export function TradeLabAuthProvider({ children }: { children: React.ReactNode }) {
-  if (AUTH_MOCK_MODE) {
+export function TradeLabAuthProvider({
+  children,
+  config
+}: {
+  children: React.ReactNode;
+  config: TradeLabAuthRuntimeConfig;
+}) {
+  if (config.mockMode) {
     return <MockAuthProvider>{children}</MockAuthProvider>;
   }
 
-  if (CLERK_PUBLISHABLE_KEY) {
+  if (config.clerkPublishableKey) {
     return (
-      <ClerkProvider publishableKey={CLERK_PUBLISHABLE_KEY}>
+      <ClerkProvider publishableKey={config.clerkPublishableKey}>
         <ClerkStateProvider>{children}</ClerkStateProvider>
       </ClerkProvider>
     );


### PR DESCRIPTION
## Summary
- move frontend auth availability to server-runtime config passed through `layout.tsx`
- keep Clerk support but allow deployed env vars to change the visible auth surface without rebuilding the image
- enable mock auth by default in the development Kubernetes overlay so the auth entrypoint is visible in the dev cluster

## Verification
- `npm.cmd run test`
- `npm.cmd run build`
- `C:\Users\marku\bin\kubectl.exe kustomize deploy\kubernetes\overlays\development > $null`
- JSON validation for `docs/ai-metadata.json`

Closes #81