### PR TITLE
Add friendly production API error handling

### DIFF
--- a/docs/ai-metadata.json
+++ b/docs/ai-metadata.json
@@ -342,6 +342,9 @@
     "followup_artifact_policy": {
       "rule": "When a change affects behavior, UI, delivery, or repository process, review and update the corresponding tests, logging, documentation, workflows, and docs/ai-metadata.json."
     },
+    "ui_error_policy": {
+      "rule": "Frontend API failures should preserve detailed backend messages in development and fall back to friendly user-facing copy in production, while logging technical detail to the browser console."
+    },
     "reproducibility_policy": {
       "rule": "Prefer repository-tracked, reproducible fixes through code, manifests, workflows, and documentation over one-off manual cluster or environment changes."
     },

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -144,6 +144,7 @@ kubectl kustomize deploy/kubernetes/overlays/production-external-secrets
 - `frontend/lib`: API client code and shared helpers
 - `frontend/lib/tradelab-auth.tsx`: auth provider boundary for guest, mock, and Clerk-backed registered modes
 - `frontend/app/layout.tsx`: server-runtime auth config handoff so Clerk or mock auth can be switched through deployed env vars without rebuilding the frontend image
+- `frontend/lib/api.ts`: centralized API error parsing with development-vs-production message handling
 - `frontend/lib/use-account-session.ts`: guest-plus-registered account orchestration plus guest session refresh logic
 - `frontend/__tests__`: component and workflow tests
 - `frontend/scripts`: utility scripts, including documentation screenshot generation

--- a/docs/system-operations.md
+++ b/docs/system-operations.md
@@ -209,6 +209,8 @@ For a release-focused view of published artifacts and release meaning, see [rele
   Usually visible as missing registered-account bootstrap, rejected Clerk bearer tokens, or an absent social-login surface when auth was expected.
 - `session security failure`
   Usually visible as missing or cleared registered app-session cookies, repeated logout loops, or guest-session refresh after an unauthorized response.
+- `user-facing API error regression`
+  In production the UI should show friendly status copy while technical backend detail stays in browser console logging and server-side logs; in development the detailed backend message may still surface in the UI.
 - `release packaging failure`
   Usually visible in GitHub Actions during image publication or manifest rendering.
 

--- a/frontend/__tests__/api-errors.test.ts
+++ b/frontend/__tests__/api-errors.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { resolveApiErrorMessage } from "@/lib/api";
+
+describe("resolveApiErrorMessage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps detailed backend messages in development mode", () => {
+    expect(
+      resolveApiErrorMessage(
+        "create order: ERROR: column \"strategy_id\" is of type uuid but expression is of type text",
+        "We couldn't place that order right now.",
+        "development"
+      )
+    ).toContain("column \"strategy_id\"");
+  });
+
+  it("returns the friendly fallback and logs detail in production mode", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    expect(
+      resolveApiErrorMessage(
+        "create order: ERROR: column \"strategy_id\" is of type uuid but expression is of type text",
+        "We couldn't place that order right now.",
+        "production"
+      )
+    ).toBe("We couldn't place that order right now.");
+    expect(errorSpy).toHaveBeenCalledWith(
+      "TradeLab API error",
+      "create order: ERROR: column \"strategy_id\" is of type uuid but expression is of type text"
+    );
+  });
+
+  it("falls back cleanly when the backend does not send a detail string", () => {
+    expect(resolveApiErrorMessage(undefined, "We couldn't load activity right now.", "production")).toBe(
+      "We couldn't load activity right now."
+    );
+  });
+});

--- a/frontend/__tests__/home.test.tsx
+++ b/frontend/__tests__/home.test.tsx
@@ -379,7 +379,7 @@ describe("Hero", () => {
     render(<Hero />);
 
     await waitFor(() => {
-      expect(screen.getByText(/failed to load candles/i)).toBeInTheDocument();
+      expect(screen.getByText(/^failed$/i)).toBeInTheDocument();
     });
 
     expect(screen.getByText(/demo buy recorded/i)).toBeInTheDocument();

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -162,6 +162,7 @@ export class ApiError extends Error {
 }
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
+const UI_ERROR_RUNTIME = process.env.NODE_ENV ?? "development";
 
 function apiUrl(path: string) {
   if (API_BASE_URL === "") {
@@ -183,7 +184,20 @@ function authHeaders(token?: string) {
 
 async function parseApiError(response: Response, fallback: string) {
   const payload = await response.json().catch(() => ({ error: fallback }));
-  throw new ApiError(payload.error ?? fallback, response.status);
+  throw new ApiError(resolveApiErrorMessage(payload.error, fallback), response.status);
+}
+
+export function resolveApiErrorMessage(detail: unknown, fallback: string, runtime = UI_ERROR_RUNTIME) {
+  const detailMessage = typeof detail === "string" ? detail.trim() : "";
+  if (runtime !== "production") {
+    return detailMessage || fallback;
+  }
+
+  if (detailMessage !== "") {
+    console.error("TradeLab API error", detailMessage);
+  }
+
+  return fallback;
 }
 
 export async function createDemoSession(): Promise<DemoSession> {
@@ -195,7 +209,7 @@ export async function createDemoSession(): Promise<DemoSession> {
   });
 
   if (!response.ok) {
-    throw new Error("Failed to create demo session");
+    await parseApiError(response, "We couldn't start a demo session right now.");
   }
 
   const data = await response.json();
@@ -211,7 +225,7 @@ export async function createDemoSession(): Promise<DemoSession> {
 export async function fetchMarkets(): Promise<Market[]> {
   const response = await fetch(apiUrl("/api/v1/markets"), { cache: "no-store" });
   if (!response.ok) {
-    throw new Error("Failed to load markets");
+    await parseApiError(response, "We couldn't load market data right now.");
   }
 
   const data = await response.json();
@@ -224,7 +238,7 @@ export async function fetchCandles(marketSymbol: string, interval = "1h", limit 
     cache: "no-store"
   });
   if (!response.ok) {
-    throw new Error("Failed to load candles");
+    await parseApiError(response, "We couldn't refresh the chart right now.");
   }
 
   const data = await response.json();
@@ -245,7 +259,7 @@ export async function fetchPortfolio(walletID: string, token: string, accounting
   });
 
   if (!response.ok) {
-    await parseApiError(response, "Failed to load portfolio");
+    await parseApiError(response, "We couldn't load the portfolio right now.");
   }
 
   const data = await response.json();
@@ -270,7 +284,7 @@ export async function fetchOrders(
     headers: authHeaders(token)
   });
   if (!response.ok) {
-    await parseApiError(response, "Failed to load orders");
+    await parseApiError(response, "We couldn't load recent orders right now.");
   }
 
   const data = await response.json();
@@ -289,7 +303,7 @@ export async function fetchActivity(token: string, options?: { marketSymbol?: st
     headers: authHeaders(token)
   });
   if (!response.ok) {
-    await parseApiError(response, "Failed to load activity");
+    await parseApiError(response, "We couldn't load activity right now.");
   }
 
   const data = await response.json();
@@ -308,7 +322,7 @@ export async function fetchStrategies(token: string, marketSymbol?: string): Pro
     headers: authHeaders(token)
   });
   if (!response.ok) {
-    await parseApiError(response, "Failed to load strategies");
+    await parseApiError(response, "We couldn't load automation right now.");
   }
 
   const data = await response.json();
@@ -336,7 +350,7 @@ export async function saveStrategy(input: {
   });
 
   if (!response.ok) {
-    await parseApiError(response, "Failed to save strategy");
+    await parseApiError(response, "We couldn't save the automation changes.");
   }
 
   const data = await response.json();
@@ -363,7 +377,7 @@ export async function patchStrategy(input: {
   });
 
   if (!response.ok) {
-    await parseApiError(response, "Failed to update strategy");
+    await parseApiError(response, "We couldn't update the automation changes.");
   }
 
   const data = await response.json();
@@ -393,7 +407,7 @@ export async function placeMarketOrder(input: {
   });
 
   if (!response.ok) {
-    await parseApiError(response, "Order failed");
+    await parseApiError(response, "We couldn't place that order right now.");
   }
 
   return response.json();
@@ -407,7 +421,7 @@ export async function bootstrapRegisteredAccount(token: string): Promise<Registe
   });
 
   if (!response.ok) {
-    await parseApiError(response, "Failed to bootstrap account");
+    await parseApiError(response, "We couldn't open the registered account right now.");
   }
 
   const data = await response.json();
@@ -440,7 +454,7 @@ export async function upgradeGuestAccount(input: {
   });
 
   if (!response.ok) {
-    await parseApiError(response, "Failed to upgrade guest account");
+    await parseApiError(response, "We couldn't upgrade this guest session right now.");
   }
 
   const data = await response.json();
@@ -461,6 +475,6 @@ export async function logoutRegisteredAccount(): Promise<void> {
   });
 
   if (!response.ok) {
-    await parseApiError(response, "Failed to log out");
+    await parseApiError(response, "We couldn't log out cleanly right now.");
   }
 }


### PR DESCRIPTION
## Summary
- centralize frontend API error presentation in `frontend/lib/api.ts`
- keep backend detail visible in development, but return friendly user-facing messages in production
- log technical backend detail to the browser console in production for debugging

## Verification
- `npm.cmd run test`
- `npm.cmd run build`
- JSON validation for `docs/ai-metadata.json`

Closes #79