### PR TITLE
Normalize empty activity and strategy responses

### DIFF
--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -301,6 +301,9 @@ func NewRouter(markets MarketLister, marketCandles MarketCandlesLister, orders O
 			writeError(w, http.StatusInternalServerError, "failed to load activity")
 			return
 		}
+		if items == nil {
+			items = []domain.ActivityLog{}
+		}
 
 		writeJSON(w, http.StatusOK, map[string]any{"activity": items})
 	})
@@ -316,6 +319,9 @@ func NewRouter(markets MarketLister, marketCandles MarketCandlesLister, orders O
 			logError(logger, "strategies.list_failed", err, "wallet_id", principal.WalletID)
 			writeError(w, http.StatusInternalServerError, "failed to load strategies")
 			return
+		}
+		if items == nil {
+			items = []domain.Strategy{}
 		}
 
 		writeJSON(w, http.StatusOK, map[string]any{"strategies": items})

--- a/backend/internal/http/router_test.go
+++ b/backend/internal/http/router_test.go
@@ -147,6 +147,24 @@ func TestListActivityRoute(t *testing.T) {
 	}
 }
 
+func TestListActivityRouteReturnsEmptyArrayWhenNoEntries(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/activity", nil)
+	req.Header.Set("Authorization", "Bearer token-1")
+	recorder := httptest.NewRecorder()
+
+	NewRouter(fakeMarketLister{}, fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}, fakeStrategyManager{}, fakeSessionManager{
+		session: domain.DemoSession{UserID: "user-1", WalletID: "wallet-1"},
+	}, fakeRegisteredAccountManager{}, discardLogger()).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", recorder.Code)
+	}
+
+	if !strings.Contains(recorder.Body.String(), `"activity":[]`) {
+		t.Fatalf("expected empty activity array in response, got %s", recorder.Body.String())
+	}
+}
+
 func TestListStrategiesRoute(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/strategies?market_symbol=XRP/USDT", nil)
 	req.Header.Set("Authorization", "Bearer token-1")
@@ -164,6 +182,24 @@ func TestListStrategiesRoute(t *testing.T) {
 
 	if !strings.Contains(recorder.Body.String(), "strategy-1") {
 		t.Fatalf("expected strategy payload in response, got %s", recorder.Body.String())
+	}
+}
+
+func TestListStrategiesRouteReturnsEmptyArrayWhenNoEntries(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/strategies", nil)
+	req.Header.Set("Authorization", "Bearer token-1")
+	recorder := httptest.NewRecorder()
+
+	NewRouter(fakeMarketLister{}, fakeMarketLister{}, fakeOrderPlacer{}, fakePortfolioGetter{}, fakeOrderHistoryLister{}, fakeActivityHistoryLister{}, fakeStrategyManager{}, fakeSessionManager{
+		session: domain.DemoSession{UserID: "user-1", WalletID: "wallet-1"},
+	}, fakeRegisteredAccountManager{}, discardLogger()).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", recorder.Code)
+	}
+
+	if !strings.Contains(recorder.Body.String(), `"strategies":[]`) {
+		t.Fatalf("expected empty strategies array in response, got %s", recorder.Body.String())
 	}
 }
 

--- a/backend/internal/service/history/service.go
+++ b/backend/internal/service/history/service.go
@@ -64,6 +64,10 @@ func (s *Service) ListActivity(ctx context.Context, walletID string, limit int, 
 		activity = filtered
 	}
 
+	if activity == nil {
+		activity = []domain.ActivityLog{}
+	}
+
 	if s.logger != nil {
 		s.logger.Info("list_activity_history.success", "operation", "list_activity_history.success", "wallet_id", walletID, "limit", limit, "result_count", len(activity))
 	}

--- a/backend/internal/service/strategy/service.go
+++ b/backend/internal/service/strategy/service.go
@@ -77,7 +77,14 @@ type PatchStrategyInput struct {
 }
 
 func (s *Service) ListStrategies(ctx context.Context, walletID string, marketSymbol string) ([]domain.Strategy, error) {
-	return s.repository.ListByWallet(ctx, walletID, marketSymbol)
+	items, err := s.repository.ListByWallet(ctx, walletID, marketSymbol)
+	if err != nil {
+		return nil, err
+	}
+	if items == nil {
+		return []domain.Strategy{}, nil
+	}
+	return items, nil
 }
 
 func (s *Service) UpsertStrategy(ctx context.Context, input UpsertStrategyInput) (domain.Strategy, error) {


### PR DESCRIPTION
## Summary
- normalize empty activity and strategy collections to [] at the HTTP boundary
- keep history and strategy services from returning nil slices for empty results
- add router regression coverage for the empty JSON contract

Closes #108