### PR TITLE
Stabilize max-position sell flow

### DIFF
--- a/frontend/__tests__/home.test.tsx
+++ b/frontend/__tests__/home.test.tsx
@@ -9,6 +9,7 @@ type FetchScenario = {
   failCandlesAfterFirst?: boolean;
   failOrder?: boolean;
   failActivityOnRefresh?: boolean;
+  initialOrderStateIndex?: number;
 };
 
 function installFetchMock(scenario: FetchScenario = {}) {
@@ -135,7 +136,7 @@ function installFetchMock(scenario: FetchScenario = {}) {
     }
   ];
 
-  let orderStateIndex = 0;
+  let orderStateIndex = scenario.initialOrderStateIndex ?? 0;
 
   vi.spyOn(global, "fetch").mockImplementation((input, init) => {
     const url = String(input);
@@ -430,5 +431,26 @@ describe("Hero", () => {
 
     expect(screen.getByLabelText(/live market chart/i)).toBeInTheDocument();
     expect(screen.getByText(/^failed$/i)).toBeInTheDocument();
+  });
+
+  it("keeps the max-position sell control disabled until the current position is loaded", async () => {
+    installFetchMock({ initialOrderStateIndex: 1 });
+
+    render(<MarketDashboard detailOnly initialMarket="XRP/USDT" />);
+
+    const maxButton = screen.getByRole("button", { name: /max position/i });
+    expect(maxButton).toBeDisabled();
+
+    await waitFor(() => {
+      expect(screen.getByText(/open qty 108.7/i)).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(maxButton).toBeEnabled();
+    });
+
+    fireEvent.click(maxButton);
+
+    expect(screen.getByLabelText(/sell quantity/i)).toHaveValue("108.7");
   });
 });

--- a/frontend/components/market-dashboard.tsx
+++ b/frontend/components/market-dashboard.tsx
@@ -222,6 +222,7 @@ export function MarketDashboard({ detailOnly = false, initialMarket = "XRP/USDT"
   const selectedStrategy = useMemo(() => availableStrategies.find((item) => item.marketSymbol === selectedMarket) ?? null, [availableStrategies, selectedMarket]);
   const visibleOrders = useMemo(() => (detailOnly ? orders.filter((order) => order.marketSymbol === selectedMarket) : orders), [detailOnly, orders, selectedMarket]);
   const visibleActivity = useMemo(() => (detailOnly ? activity.filter((item) => item.marketSymbol === selectedMarket || item.marketSymbol === "") : activity), [activity, detailOnly, selectedMarket]);
+  const canUseMaxSell = Boolean(selectedPosition && selectedPosition.openQuantity > 0);
   const accountSummary = registeredAccount && auth.user ? auth.user.displayName : guestSession ? `${guestSession.walletID.slice(0, 8)}...` : "--";
   const lastPrice = candles.length > 0 ? candles[candles.length - 1].closePrice : null;
   const chartRefreshLabel = isChartRefreshing ? "Refreshing..." : "Refresh now";
@@ -502,7 +503,7 @@ export function MarketDashboard({ detailOnly = false, initialMarket = "XRP/USDT"
                       const nextQuantity = String(selectedPosition.openQuantity);
                       sellBaseQuantityRef.current = nextQuantity;
                       setSellBaseQuantity(nextQuantity);
-                    }} className="rounded-2xl border border-[var(--line)] px-4 py-3 text-sm font-medium text-[var(--muted)]">Max position</button>
+                    }} disabled={!canUseMaxSell} className="rounded-2xl border border-[var(--line)] px-4 py-3 text-sm font-medium text-[var(--muted)] disabled:cursor-not-allowed disabled:opacity-50">Max position</button>
                     <button type="submit" disabled={isSubmitting || !activeWalletID || !selectedPosition} className="rounded-2xl bg-[var(--accent-warm)] px-5 py-4 font-semibold text-[#04111a] disabled:opacity-60">{isSubmitting ? "Executing..." : "Run demo sell"}</button>
                   </form>
                 </div>

--- a/frontend/e2e/home.spec.ts
+++ b/frontend/e2e/home.spec.ts
@@ -599,6 +599,8 @@ test("executes a partial sell from the market detail page", async ({ page }) => 
 
 test("closes the position with a max sell", async ({ page }) => {
   await page.goto("/markets/XRP%2FUSDT");
+  await expect(page.getByText(/open qty 74.62/i)).toBeVisible();
+  await expect(page.getByRole("button", { name: /max position/i })).toBeEnabled();
   await page.getByRole("button", { name: /max position/i }).click();
   await expect(page.getByLabel(/sell quantity/i)).toHaveValue("74.62");
   await page.getByRole("button", { name: /run demo sell/i }).click();


### PR DESCRIPTION
Closes #113

## Summary
- disable the market-detail `Max position` control until the current position is loaded
- wait for the loaded position state in the max-sell E2E test
- add unit coverage for the disabled->enabled max-sell path

## Verification
- npm.cmd run test -- --testNamePattern "max-position sell control|auto-refreshes the market-detail chart|keeps balances visible|success message and refreshes portfolio panels"
- npm.cmd run test:e2e
- npm.cmd run build
