### PR TITLE
Add coverage and source doc quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,13 @@ jobs:
         with:
           go-version-file: backend/go.mod
 
-      - name: Run backend tests
+      - name: Run backend tests with coverage
         working-directory: backend
-        run: go test ./...
+        run: go test ./... -coverprofile=coverage.out
+
+      - name: Enforce backend coverage floor
+        working-directory: backend
+        run: go run ./cmd/coveragecheck -file coverage.out -min 40
 
   frontend-test:
     name: Frontend unit tests
@@ -45,9 +49,9 @@ jobs:
         working-directory: frontend
         run: npm ci
 
-      - name: Run frontend unit tests
+      - name: Run frontend unit tests with coverage
         working-directory: frontend
-        run: npm run test
+        run: npm run test:coverage
 
   frontend-build:
     name: Frontend build
@@ -179,3 +183,19 @@ jobs:
 
       - name: Validate AI metadata JSON
         run: node -e "JSON.parse(require('fs').readFileSync('docs/ai-metadata.json','utf8'));"
+
+  source-docs-validation:
+    name: Source-code documentation quality
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Validate source-code documentation
+        run: node scripts/check-source-docs.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 node_modules/
 .next/
 coverage/
+backend/coverage.out
+backend/coverage
 playwright-report/
 test-results/
 backend/bin/

--- a/backend/cmd/coveragecheck/main.go
+++ b/backend/cmd/coveragecheck/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+)
+
+var totalCoveragePattern = regexp.MustCompile(`total:\s+\(statements\)\s+([0-9.]+)%`)
+
+func main() {
+	var (
+		filePath = flag.String("file", "coverage.out", "path to the Go coverage profile")
+		minimum  = flag.Float64("min", 40, "minimum total statement coverage percentage")
+	)
+
+	flag.Parse()
+
+	output, err := exec.Command("go", "tool", "cover", "-func="+*filePath).CombinedOutput()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "run go tool cover: %v\n%s", err, string(output))
+		os.Exit(1)
+	}
+
+	total, err := parseTotalCoverage(string(output))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "parse total coverage: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Backend total coverage: %.1f%% (minimum %.1f%%)\n", total, *minimum)
+	if total < *minimum {
+		fmt.Fprintf(os.Stderr, "backend coverage gate failed: %.1f%% is below %.1f%%\n", total, *minimum)
+		os.Exit(1)
+	}
+}
+
+func parseTotalCoverage(profile string) (float64, error) {
+	// The raw coverage profile does not contain the total. Reuse the standard
+	// summary format by asking callers to provide `go tool cover -func` output
+	// when needed, but also support plain profile data by failing clearly.
+	matches := totalCoveragePattern.FindStringSubmatch(profile)
+	if len(matches) != 2 {
+		return 0, fmt.Errorf("total coverage line not found")
+	}
+
+	value, err := strconv.ParseFloat(matches[1], 64)
+	if err != nil {
+		return 0, err
+	}
+
+	return value, nil
+}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 )
 
+// Config collects the backend runtime settings needed to boot the API process.
 type Config struct {
 	HTTPAddress           string
 	DatabaseURL           string
@@ -16,6 +17,7 @@ type Config struct {
 	StrategyEngineTick    time.Duration
 }
 
+// Load resolves the runtime configuration from the environment with local-safe defaults.
 func Load() Config {
 	return Config{
 		HTTPAddress:           getEnv("HTTP_ADDRESS", ":8080"),

--- a/backend/internal/domain/account.go
+++ b/backend/internal/domain/account.go
@@ -7,6 +7,7 @@ const (
 	PrincipalKindRegistered PrincipalKind = "registered"
 )
 
+// Principal represents the authenticated TradeLab actor used for authorization decisions.
 type Principal struct {
 	Kind        PrincipalKind `json:"kind"`
 	UserID      string        `json:"userID"`
@@ -21,6 +22,7 @@ type RegisteredIdentity struct {
 	DisplayName string `json:"displayName"`
 }
 
+// RegisteredAccount is the durable application account mapped from a Clerk identity.
 type RegisteredAccount struct {
 	UserID      string `json:"userID"`
 	WalletID    string `json:"walletID"`

--- a/backend/internal/domain/market.go
+++ b/backend/internal/domain/market.go
@@ -2,6 +2,7 @@ package domain
 
 import "time"
 
+// Market describes a tradable symbol and its execution constraints.
 type Market struct {
 	ID          string  `json:"id"`
 	Symbol      string  `json:"symbol"`
@@ -28,6 +29,7 @@ type MarketDataMeta struct {
 	GeneratedAt time.Time `json:"generated_at"`
 }
 
+// CandleFeed bundles chart candles with metadata about feed freshness.
 type CandleFeed struct {
 	Candles []Candle
 	Meta    MarketDataMeta

--- a/backend/internal/domain/order.go
+++ b/backend/internal/domain/order.go
@@ -26,6 +26,7 @@ const (
 	AccountingModeHybrid      AccountingMode = "hybrid"
 )
 
+// Order records a simulated trade execution and its portfolio impact.
 type Order struct {
 	ID            string      `json:"id"`
 	UserID        string      `json:"userID"`
@@ -80,6 +81,7 @@ type PortfolioAllocation struct {
 	Weight       float64 `json:"weight"`
 }
 
+// PortfolioSummary is the aggregate portfolio view rendered in the UI.
 type PortfolioSummary struct {
 	WalletID       string                `json:"walletID"`
 	BaseCurrency   string                `json:"baseCurrency"`
@@ -94,6 +96,7 @@ type PortfolioSummary struct {
 	Allocations    []PortfolioAllocation `json:"allocations"`
 }
 
+// ActivityLog stores user-facing timeline entries for trading and automation events.
 type ActivityLog struct {
 	ID           string    `json:"id"`
 	WalletID     string    `json:"walletID"`
@@ -104,6 +107,7 @@ type ActivityLog struct {
 	CreatedAt    time.Time `json:"createdAt"`
 }
 
+// NormalizeAccountingMode maps arbitrary input onto the supported accounting modes.
 func NormalizeAccountingMode(raw string) AccountingMode {
 	switch AccountingMode(raw) {
 	case AccountingModeFIFO:

--- a/backend/internal/domain/strategy.go
+++ b/backend/internal/domain/strategy.go
@@ -21,6 +21,7 @@ const (
 	StrategyOutcomeErrored  StrategyOutcome = "errored"
 )
 
+// StrategyConfig groups the automation rules that can be evaluated for one market.
 type StrategyConfig struct {
 	DipBuy     DipBuyRule     `json:"dipBuy"`
 	TakeProfit TakeProfitRule `json:"takeProfit"`
@@ -43,6 +44,7 @@ type StopLossRule struct {
 	TriggerPercent float64 `json:"triggerPercent"`
 }
 
+// Strategy represents one automation bundle for a specific wallet and market.
 type Strategy struct {
 	ID                   string           `json:"id"`
 	UserID               string           `json:"userID"`
@@ -62,6 +64,7 @@ type Strategy struct {
 	UpdatedAt            time.Time        `json:"updatedAt"`
 }
 
+// StrategyRun captures one evaluation attempt of a strategy bundle.
 type StrategyRun struct {
 	ID                   string           `json:"id"`
 	StrategyID           string           `json:"strategyID"`

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -19,6 +19,7 @@ import (
 	strategyservice "github.com/aidun/tradelab/backend/internal/service/strategy"
 )
 
+// MarketLister provides the public market catalogue used by the HTTP layer.
 type MarketLister interface {
 	List(ctx context.Context) ([]domain.Market, error)
 }
@@ -27,6 +28,7 @@ type MarketCandlesLister interface {
 	ListCandles(ctx context.Context, marketSymbol string, interval string, limit int) (domain.CandleFeed, error)
 }
 
+// OrderPlacer executes validated market orders on behalf of the HTTP handlers.
 type OrderPlacer interface {
 	PlaceMarketOrder(ctx context.Context, input orderservice.PlaceMarketOrderInput) (domain.Order, error)
 }
@@ -43,6 +45,7 @@ type ActivityHistoryLister interface {
 	ListActivity(ctx context.Context, walletID string, limit int, marketSymbol string) ([]domain.ActivityLog, error)
 }
 
+// StrategyManager exposes strategy listing and mutation operations to the router.
 type StrategyManager interface {
 	ListStrategies(ctx context.Context, walletID string, marketSymbol string) ([]domain.Strategy, error)
 	UpsertStrategy(ctx context.Context, input strategyservice.UpsertStrategyInput) (domain.Strategy, error)
@@ -64,6 +67,7 @@ type RegisteredAccountManager interface {
 
 const registeredSessionCookieName = "tradelab_app_session"
 
+// NewRouter wires the TradeLab HTTP API and its authentication boundaries.
 func NewRouter(markets MarketLister, marketCandles MarketCandlesLister, orders OrderPlacer, portfolios PortfolioGetter, orderHistory OrderHistoryLister, activityHistory ActivityHistoryLister, strategies StrategyManager, sessions DemoSessionManager, registeredAccounts RegisteredAccountManager, logger *slog.Logger) http.Handler {
 	mux := http.NewServeMux()
 

--- a/docs/ai-metadata.json
+++ b/docs/ai-metadata.json
@@ -93,6 +93,8 @@
     "live_trading": false,
     "maintenance_expectations": [
       "Keep tests aligned with behavior changes.",
+      "Preserve or intentionally raise the enforced backend and frontend coverage floors when testable behavior changes.",
+      "Keep the curated source-code documentation check aligned with important exported/public surfaces when those interfaces change.",
       "Adjust structured logging when backend control flow changes.",
       "Update documentation and docs/ai-metadata.json when repository structure, onboarding, workflows, or infrastructure bootstrap materially change.",
       "Update GitHub Actions when quality gates, delivery behavior, or infrastructure validation need to evolve."
@@ -137,8 +139,29 @@
       "Backend container build",
       "Frontend container build",
       "Kubernetes manifests",
-      "Metadata validation"
+      "Metadata validation",
+      "Source-code documentation quality"
     ],
+    "coverage_thresholds": {
+      "backend_total_statements_min": 40,
+      "frontend_components_and_lib": {
+        "statements_min": 45,
+        "lines_min": 45,
+        "functions_min": 50,
+        "branches_min": 50
+      }
+    },
+    "source_code_documentation_gate": {
+      "type": "curated exported-surface check",
+      "script": "scripts/check-source-docs.mjs",
+      "focus": [
+        "backend configuration and domain contracts",
+        "backend HTTP router interfaces",
+        "frontend dashboard entrypoints",
+        "frontend auth/session orchestration",
+        "frontend API client surface"
+      ]
+    },
     "github_actions_sequence": [
       {
         "workflow": "CI",
@@ -151,7 +174,8 @@
           "Backend container build",
           "Frontend container build",
           "Kubernetes manifests",
-          "Metadata validation"
+          "Metadata validation",
+          "Source-code documentation quality"
         ]
       },
       {

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -188,6 +188,17 @@ The CI workflow runs these jobs in parallel:
 - `Frontend container build`
 - `Kubernetes manifests`
 - `Metadata validation`
+- `Source-code documentation quality`
+
+The quality gates now also enforce:
+
+- backend total statement coverage must stay at or above `40%`
+- frontend unit-test coverage for `components/*` and `lib/*` must stay at or above:
+  - `45%` statements
+  - `45%` lines
+  - `50%` functions
+  - `50%` branches
+- curated source-code documentation checks for key exported backend and frontend surfaces
 
 ### Auto Merge PR
 
@@ -277,6 +288,7 @@ When making changes, consult the `artifact_groups` and `change_management` secti
 - market-data behavior now includes bounded stale fallback semantics
 - backend request and service flow now emits structured JSON logs through `log/slog`
 - frontend quality gates now include Playwright coverage for core dashboard journeys
+- CI now enforces baseline coverage floors and a curated source-code documentation check
 - Phase 4 adds a global accounting-mode UI and a dedicated `/markets/[symbol]` route for the focused trading flow
 - Phase 5 adds a strategy bundle per `wallet + market` with in-process evaluation and strategy-specific order/activity visibility
 - release-ready Kubernetes output should use immutable release tags, not rely on `latest`

--- a/frontend/components/hero.tsx
+++ b/frontend/components/hero.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { MarketDashboard } from "@/components/market-dashboard";
 
+/** Hero renders the default dashboard entrypoint used on the homepage. */
 export function Hero() {
   return <MarketDashboard />;
 }

--- a/frontend/components/market-dashboard.tsx
+++ b/frontend/components/market-dashboard.tsx
@@ -92,6 +92,7 @@ function CandleChart({ candles }: { candles: Candle[] }) {
   );
 }
 
+/** MarketDashboard renders the overview and market-detail trading experience. */
 export function MarketDashboard({ detailOnly = false, initialMarket = "XRP/USDT" }: MarketDashboardProps) {
   const auth = useTradeLabAuth();
   const buildInfo = resolveBuildInfo();

--- a/frontend/components/metric-card.tsx
+++ b/frontend/components/metric-card.tsx
@@ -6,6 +6,7 @@ type MetricCardProps = {
   trend: string;
 };
 
+/** MetricCard renders one compact portfolio metric in the overview header. */
 export function MetricCard({ label, value, trend }: MetricCardProps) {
   return (
     <div className="rounded-[28px] border border-[var(--line)] bg-[var(--surface)] p-5 backdrop-blur">

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -151,6 +151,7 @@ export type CandleFeed = {
   meta: MarketDataMeta;
 };
 
+/** ApiError wraps backend and transport failures with an HTTP status for UI handling. */
 export class ApiError extends Error {
   status: number;
 
@@ -191,6 +192,7 @@ async function parseApiError(response: Response, fallback: string) {
   throw new ApiError(resolveApiErrorMessage(payload.error, fallback), response.status);
 }
 
+/** resolveApiErrorMessage maps technical API failures to the current UI runtime contract. */
 export function resolveApiErrorMessage(detail: unknown, fallback: string, runtime = UI_ERROR_RUNTIME) {
   const detailMessage = typeof detail === "string" ? detail.trim() : "";
   if (runtime !== "production") {
@@ -204,6 +206,7 @@ export function resolveApiErrorMessage(detail: unknown, fallback: string, runtim
   return fallback;
 }
 
+/** createDemoSession provisions a guest trading session for the browser. */
 export async function createDemoSession(): Promise<DemoSession> {
   const response = await fetch(apiUrl("/api/v1/sessions/demo"), {
     method: "POST",
@@ -255,6 +258,7 @@ export async function fetchCandles(marketSymbol: string, interval = "1h", limit 
   };
 }
 
+/** fetchPortfolio loads the portfolio summary for the active wallet and accounting mode. */
 export async function fetchPortfolio(walletID: string, token: string, accountingMode: AccountingMode): Promise<PortfolioSummary> {
   const response = await fetch(apiUrl(`/api/v1/portfolios/${walletID}?accounting_mode=${accountingMode}`), {
     cache: "no-store",
@@ -270,6 +274,7 @@ export async function fetchPortfolio(walletID: string, token: string, accounting
   return data.portfolio;
 }
 
+/** fetchOrders loads the recent order history for the active account scope. */
 export async function fetchOrders(
   token: string,
   options?: { accountingMode?: AccountingMode; marketSymbol?: string }
@@ -295,6 +300,7 @@ export async function fetchOrders(
   return ensureArray<Order>(data.orders);
 }
 
+/** fetchActivity loads user-facing activity entries, optionally filtered to one market. */
 export async function fetchActivity(token: string, options?: { marketSymbol?: string }): Promise<ActivityLog[]> {
   const params = new URLSearchParams();
   if (options?.marketSymbol) {
@@ -314,6 +320,7 @@ export async function fetchActivity(token: string, options?: { marketSymbol?: st
   return ensureArray<ActivityLog>(data.activity);
 }
 
+/** fetchStrategies loads automation bundles for the active wallet and optional market. */
 export async function fetchStrategies(token: string, marketSymbol?: string): Promise<Strategy[]> {
   const params = new URLSearchParams();
   if (marketSymbol) {
@@ -388,6 +395,7 @@ export async function patchStrategy(input: {
   return data.strategy;
 }
 
+/** placeMarketOrder submits a buy or sell order through the backend trading API. */
 export async function placeMarketOrder(input: {
   side: "buy" | "sell";
   marketSymbol: string;

--- a/frontend/lib/build-info.ts
+++ b/frontend/lib/build-info.ts
@@ -10,6 +10,7 @@ function cleanValue(value: string | undefined, fallback: string) {
   return trimmed ? trimmed : fallback;
 }
 
+/** resolveBuildInfo normalizes the release metadata exposed in the UI. */
 export function resolveBuildInfo(env: NodeJS.ProcessEnv = process.env): BuildInfo {
   const release = cleanValue(env.NEXT_PUBLIC_BUILD_RELEASE, "local-dev");
   const branch = cleanValue(env.NEXT_PUBLIC_BUILD_BRANCH, "workspace");

--- a/frontend/lib/tradelab-auth.tsx
+++ b/frontend/lib/tradelab-auth.tsx
@@ -44,6 +44,7 @@ const TradeLabAuthContext = createContext<TradeLabAuthContextValue>({
   signOut: async () => undefined
 });
 
+/** TradeLabAuthProvider selects the active auth runtime and exposes it to the app shell. */
 export function TradeLabAuthProvider({
   children,
   config
@@ -66,10 +67,12 @@ export function TradeLabAuthProvider({
   return <FallbackAuthProvider>{children}</FallbackAuthProvider>;
 }
 
+/** useTradeLabAuth returns the active auth runtime contract for the UI. */
 export function useTradeLabAuth() {
   return useContext(TradeLabAuthContext);
 }
 
+/** AuthEntryActions renders the visible sign-in and sign-up entrypoints. */
 export function AuthEntryActions() {
   const auth = useTradeLabAuth();
 
@@ -124,6 +127,7 @@ export function AuthEntryActions() {
   return null;
 }
 
+/** AuthStatusControls renders the signed-in logout affordance. */
 export function AuthStatusControls() {
   const auth = useTradeLabAuth();
 

--- a/frontend/lib/use-account-session.ts
+++ b/frontend/lib/use-account-session.ts
@@ -53,6 +53,7 @@ type CoreDataState = {
   activeAccessToken: () => Promise<string | null>;
 };
 
+/** useAccountSession orchestrates guest and registered account state plus dashboard data loading. */
 export function useAccountSession(): CoreDataState {
   const auth = useTradeLabAuth();
   const previousAuthStatus = useRef(auth.status);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "@types/node": "24.7.2",
         "@types/react": "19.2.2",
         "@types/react-dom": "19.2.2",
+        "@vitest/coverage-v8": "^3.2.4",
         "autoprefixer": "10.4.21",
         "jsdom": "27.0.1",
         "postcss": "8.5.6",
@@ -47,6 +48,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -99,6 +114,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
@@ -109,6 +134,22 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
@@ -117,6 +158,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@clerk/backend": {
@@ -1306,6 +1371,34 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1527,6 +1620,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@playwright/test": {
@@ -2096,6 +2200,40 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -2292,6 +2430,25 @@
         "node": ">=12"
       }
     },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -2330,6 +2487,16 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.12",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
@@ -2364,6 +2531,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -2524,6 +2704,26 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -2532,6 +2732,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/css-tree": {
@@ -2690,12 +2905,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.328",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.328.tgz",
       "integrity": "sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -2848,6 +3077,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
@@ -2887,6 +3133,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2905,6 +3173,49 @@
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/hasown": {
       "version": "2.0.2",
@@ -2931,6 +3242,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -3022,6 +3340,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -3051,6 +3379,83 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/jiti": {
       "version": "1.21.7",
@@ -3175,6 +3580,34 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
@@ -3214,6 +3647,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -3380,6 +3839,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parse5": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
@@ -3393,12 +3859,46 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -3867,8 +4367,8 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "devOptional": true,
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -3927,12 +4427,48 @@
         "@img/sharp-win32-x64": "0.34.5"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -3965,6 +4501,103 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -4043,6 +4676,19 @@
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -4137,6 +4783,21 @@
         "ts-node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/thenify": {
@@ -4676,6 +5337,22 @@
         "node": ">=20"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -4691,6 +5368,107 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/ws": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "docs:screenshots": "node ./scripts/capture-doc-screenshots.mjs"
@@ -25,6 +26,7 @@
     "@types/node": "24.7.2",
     "@types/react": "19.2.2",
     "@types/react-dom": "19.2.2",
+    "@vitest/coverage-v8": "^3.2.4",
     "autoprefixer": "10.4.21",
     "jsdom": "27.0.1",
     "postcss": "8.5.6",

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -11,6 +11,18 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: ["./vitest.setup.ts"],
-    include: ["__tests__/**/*.test.ts?(x)"]
+    include: ["__tests__/**/*.test.ts?(x)"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json-summary"],
+      include: ["components/**/*.{ts,tsx}", "lib/**/*.{ts,tsx}"],
+      exclude: ["**/*.test.ts", "**/*.test.tsx"],
+      thresholds: {
+        statements: 45,
+        lines: 45,
+        functions: 50,
+        branches: 50
+      }
+    }
   }
 });

--- a/scripts/check-source-docs.mjs
+++ b/scripts/check-source-docs.mjs
@@ -1,0 +1,115 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+
+const rules = [
+  {
+    file: "backend/internal/config/config.go",
+    kind: "go",
+    symbols: ["Config", "Load"]
+  },
+  {
+    file: "backend/internal/domain/account.go",
+    kind: "go",
+    symbols: ["Principal", "RegisteredAccount"]
+  },
+  {
+    file: "backend/internal/domain/market.go",
+    kind: "go",
+    symbols: ["Market", "CandleFeed"]
+  },
+  {
+    file: "backend/internal/domain/order.go",
+    kind: "go",
+    symbols: ["Order", "PortfolioSummary", "ActivityLog", "NormalizeAccountingMode"]
+  },
+  {
+    file: "backend/internal/domain/strategy.go",
+    kind: "go",
+    symbols: ["StrategyConfig", "Strategy", "StrategyRun"]
+  },
+  {
+    file: "backend/internal/http/router.go",
+    kind: "go",
+    symbols: ["MarketLister", "OrderPlacer", "StrategyManager", "NewRouter"]
+  },
+  {
+    file: "frontend/components/hero.tsx",
+    kind: "ts",
+    symbols: ["Hero"]
+  },
+  {
+    file: "frontend/components/market-dashboard.tsx",
+    kind: "ts",
+    symbols: ["MarketDashboard"]
+  },
+  {
+    file: "frontend/lib/api.ts",
+    kind: "ts",
+    symbols: [
+      "ApiError",
+      "resolveApiErrorMessage",
+      "createDemoSession",
+      "fetchPortfolio",
+      "fetchOrders",
+      "fetchActivity",
+      "fetchStrategies",
+      "placeMarketOrder"
+    ]
+  },
+  {
+    file: "frontend/lib/build-info.ts",
+    kind: "ts",
+    symbols: ["resolveBuildInfo"]
+  },
+  {
+    file: "frontend/lib/tradelab-auth.tsx",
+    kind: "ts",
+    symbols: ["TradeLabAuthProvider", "useTradeLabAuth", "AuthEntryActions", "AuthStatusControls"]
+  },
+  {
+    file: "frontend/lib/use-account-session.ts",
+    kind: "ts",
+    symbols: ["useAccountSession"]
+  }
+];
+
+const failures = [];
+
+for (const rule of rules) {
+  const absolutePath = path.join(repoRoot, rule.file);
+  const source = readFileSync(absolutePath, "utf8");
+
+  for (const symbol of rule.symbols) {
+    const documented = rule.kind === "go" ? hasGoDoc(source, symbol) : hasTsDoc(source, symbol);
+    if (!documented) {
+      failures.push(`${rule.file}: missing source-code documentation for ${symbol}`);
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Source-code documentation check failed:");
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Source-code documentation check passed for ${rules.length} curated public surfaces.`);
+
+function hasGoDoc(source, symbol) {
+  const pattern = new RegExp(`//\\s+${escapeRegex(symbol)}\\b[\\s\\S]*?\\n(?:type|func)\\s+${escapeRegex(symbol)}\\b`, "m");
+  return pattern.test(source);
+}
+
+function hasTsDoc(source, symbol) {
+  const jsDocPattern = new RegExp(`/\\*\\*[\\s\\S]*?\\*/\\s*export\\s+(?:async\\s+)?(?:function|class)\\s+${escapeRegex(symbol)}\\b`, "m");
+  const lineCommentPattern = new RegExp(`//\\s+${escapeRegex(symbol)}\\b.*\\nexport\\s+(?:async\\s+)?(?:function|class)\\s+${escapeRegex(symbol)}\\b`, "m");
+  return jsDocPattern.test(source) || lineCommentPattern.test(source);
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
Closes #116

## Summary
- add backend and frontend coverage gates to CI
- add a curated source-code documentation quality check
- document the new quality expectations in the contributor guide and AI metadata

## Verification
- go test ./... -coverprofile=coverage.out
- go run ./cmd/coveragecheck -file coverage.out -min 40
- npm.cmd run test:coverage
- node scripts/check-source-docs.mjs
- npm.cmd run build
- Get-Content docs\ai-metadata.json -Raw | ConvertFrom-Json | Out-Null
