### PR TITLE
Add README badges for CI quality gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # TradeLab
 
 [![CI](https://github.com/aidun/tradelab/actions/workflows/ci.yml/badge.svg)](https://github.com/aidun/tradelab/actions/workflows/ci.yml)
+[![Backend Coverage Floor](https://img.shields.io/badge/backend_coverage-%E2%89%A540%25-2ea043)](docs/developer-guide.md#quality-gates)
+[![Frontend Coverage Gate](https://img.shields.io/badge/frontend_coverage-gated%20(45%2F45%2F50%2F50)-1f6feb)](docs/developer-guide.md#quality-gates)
+[![Source Docs Gate](https://img.shields.io/badge/source_docs-enforced-8250df)](docs/developer-guide.md#quality-gates)
 [![Release](https://img.shields.io/github/v/release/aidun/tradelab?display_name=tag)](https://github.com/aidun/tradelab/releases)
 [![License](https://img.shields.io/github/license/aidun/tradelab)](LICENSE)
 
@@ -84,6 +87,8 @@ For the exact PR -> CI -> merge -> release sequence, see:
 
 - [docs/system-operations.md](docs/system-operations.md)
 - [docs/release-process.md](docs/release-process.md)
+
+The coverage and source-doc badges on this page reflect enforced CI quality gates, not a live third-party coverage telemetry service.
 
 ## Public roadmap
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -190,6 +190,8 @@ The CI workflow runs these jobs in parallel:
 - `Metadata validation`
 - `Source-code documentation quality`
 
+### Quality gates
+
 The quality gates now also enforce:
 
 - backend total statement coverage must stay at or above `40%`
@@ -199,6 +201,8 @@ The quality gates now also enforce:
   - `50%` functions
   - `50%` branches
 - curated source-code documentation checks for key exported backend and frontend surfaces
+
+The README quality badges point to this section. They intentionally document enforced gates and floors, not live third-party telemetry.
 
 ### Auto Merge PR
 


### PR DESCRIPTION
## Summary\n- add visible README badges for the enforced backend/frontend coverage gates and the source-doc quality gate\n- add a stable Quality gates anchor in the developer guide for those badge links\n- clarify that the badges represent enforced CI gates, not live third-party telemetry\n\n## Testing\n- checked current master CI workflow contains the merged coverage and source-doc jobs\n- verified README badge entries\n- verified developer-guide Quality gates anchor and explanatory note\n\nCloses #118