### PR TITLE
Always manage the production Argo application

### DIFF
--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -90,17 +90,11 @@ jobs:
 
           prod_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
-          kustomization = Path("deploy/infrastructure/applications/kustomization.yaml")
-          kustomization_text = kustomization.read_text(encoding="utf-8")
-          if "  - tradelab-prod.yaml\n" not in kustomization_text:
-            kustomization_text += "  - tradelab-prod.yaml\n"
-          kustomization.write_text(kustomization_text, encoding="utf-8")
-
       - name: Commit promotion change
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add deploy/infrastructure/applications/tradelab-prod.yaml deploy/infrastructure/applications/kustomization.yaml
+          git add deploy/infrastructure/applications/tradelab-prod.yaml
           if git diff --cached --quiet; then
             echo "Production already points at the requested release tag."
             exit 0

--- a/deploy/infrastructure/applications/kustomization.yaml
+++ b/deploy/infrastructure/applications/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - metallb.yaml
   - traefik.yaml
   - tradelab-dev.yaml
+  - tradelab-prod.yaml

--- a/docs/ai-metadata.json
+++ b/docs/ai-metadata.json
@@ -218,7 +218,7 @@
         "conditions": [
           "requested release tag exists as an official GitHub release or the latest release is resolved automatically"
         ],
-        "action": "Update the production Argo CD application to the selected official release tag on master"
+        "action": "Update the always-present production Argo CD application to the selected official release tag on master"
       }
     ],
     "observability": [
@@ -261,10 +261,8 @@
         "deploy/infrastructure/applications/metallb.yaml",
         "deploy/infrastructure/applications/traefik.yaml"
       ],
-    "managed_by_root": [
-        "deploy/infrastructure/applications/tradelab-dev.yaml"
-      ],
-      "prepared_next_step": [
+      "managed_by_root": [
+        "deploy/infrastructure/applications/tradelab-dev.yaml",
         "deploy/infrastructure/applications/tradelab-prod.yaml"
       ],
       "environment_revision_policy": {

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -224,6 +224,8 @@ The production promotion workflow is also manual.
 
 It resolves the requested or latest official GitHub release and updates the production Argo CD application to that release tag.
 
+`tradelab-prod` stays in the Argo root application set at all times. The manual workflow only advances its release target.
+
 ### Publish Master Images
 
 Every merge to `master` builds and publishes backend and frontend development images with both:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -58,7 +58,7 @@ TradeLab publishes two image classes:
 
 - `tradelab-dev` always follows `master`
 - `tradelab-prod` is promoted only to an official GitHub release tag
-- production promotion is handled by the `Promote Production` workflow, which updates the Argo CD production application to the selected or latest published release
+- production promotion is handled by the `Promote Production` workflow, which updates the always-present Argo CD production application to the selected or latest published release
 
 ## What a release signals
 

--- a/docs/system-operations.md
+++ b/docs/system-operations.md
@@ -175,8 +175,9 @@ It:
 
 1. resolves the selected or latest GitHub release tag
 2. updates [tradelab-prod.yaml](../deploy/infrastructure/applications/tradelab-prod.yaml)
-3. ensures the production application is part of the Argo CD root kustomization
-4. commits the promotion change back to `master`
+3. commits the promotion change back to `master`
+
+`tradelab-prod` is always part of the Argo CD root application set. Production promotion only moves its target release; it does not create the application for the first time.
 
 This means the effective repository delivery path is:
 


### PR DESCRIPTION
## Summary
- add tradelab-prod to the root-managed Argo application kustomization
- simplify Promote Production so it only updates the existing prod app target
- align docs and ai metadata with the always-present prod-app model

## Testing
- kubectl kustomize deploy/infrastructure/applications
- kubectl kustomize deploy/infrastructure/bootstrap/root-application
- AI metadata JSON parse validation
- git diff --check

Closes #110