### PR TITLE
Improve the trading UI accessibility and density

### DIFF
--- a/frontend/__tests__/home.test.tsx
+++ b/frontend/__tests__/home.test.tsx
@@ -471,6 +471,6 @@ describe("Hero", () => {
 
     fireEvent.click(maxButton);
 
-    expect(screen.getByLabelText(/sell quantity/i)).toHaveValue("108.7");
+    expect(screen.getByLabelText(/sell quantity/i)).toHaveValue(108.7);
   });
 });

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -20,6 +20,8 @@
 }
 
 html {
+  color-scheme: dark;
+  overflow-x: hidden;
   background:
     radial-gradient(circle at top left, rgba(110, 242, 211, 0.16), transparent 30%),
     radial-gradient(circle at 80% 20%, rgba(255, 184, 107, 0.16), transparent 25%),
@@ -29,6 +31,7 @@ html {
 body {
   margin: 0;
   min-height: 100vh;
+  overflow-x: hidden;
   color: var(--text);
   font-family: var(--font-display), sans-serif;
 }
@@ -36,6 +39,35 @@ body {
 a {
   color: inherit;
   text-decoration: none;
+}
+
+button,
+input,
+select,
+textarea,
+a {
+  -webkit-tap-highlight-color: rgba(110, 242, 211, 0.18);
+  touch-action: manipulation;
+}
+
+.tabular-data {
+  font-variant-numeric: tabular-nums;
+}
+
+.focus-ring {
+  transition:
+    border-color 160ms ease,
+    background-color 160ms ease,
+    box-shadow 160ms ease,
+    color 160ms ease,
+    opacity 160ms ease;
+}
+
+.focus-ring:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 1px rgba(4, 11, 21, 1),
+    0 0 0 3px rgba(110, 242, 211, 0.68);
 }
 
 .grid-glow {
@@ -52,4 +84,15 @@ a {
     linear-gradient(90deg, rgba(255, 255, 255, 0.04) 1px, transparent 1px);
   background-size: 48px 48px;
   mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.9), transparent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/frontend/components/market-dashboard.tsx
+++ b/frontend/components/market-dashboard.tsx
@@ -15,6 +15,19 @@ type MarketDashboardProps = {
 
 export const CHART_AUTO_REFRESH_MS = 30_000;
 
+const baseControlClassName =
+  "focus-ring rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.6)] px-4 py-3 text-[var(--text)] hover:border-[rgba(110,242,211,0.4)]";
+const secondaryButtonClassName =
+  "focus-ring rounded-2xl border border-[var(--line)] px-4 py-3 text-sm font-medium text-[var(--text)] hover:border-[var(--accent)] hover:text-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-60";
+const accentButtonClassName =
+  "focus-ring rounded-2xl bg-[var(--accent)] px-4 py-3 text-sm font-semibold text-[#04111a] hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-60";
+const warmButtonClassName =
+  "focus-ring rounded-2xl bg-[var(--accent-warm)] px-4 py-3 text-sm font-semibold text-[#04111a] hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-60";
+
+function EmptyPanelState({ children }: { children: React.ReactNode }) {
+  return <div className="rounded-2xl border border-dashed border-[var(--line)] px-4 py-6 text-sm text-[var(--muted)]">{children}</div>;
+}
+
 function formatCurrency(value: number) {
   return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 2 }).format(value);
 }
@@ -224,9 +237,9 @@ export function MarketDashboard({ detailOnly = false, initialMarket = "XRP/USDT"
   const visibleOrders = useMemo(() => (detailOnly ? orders.filter((order) => order.marketSymbol === selectedMarket) : orders), [detailOnly, orders, selectedMarket]);
   const visibleActivity = useMemo(() => (detailOnly ? activity.filter((item) => item.marketSymbol === selectedMarket || item.marketSymbol === "") : activity), [activity, detailOnly, selectedMarket]);
   const canUseMaxSell = Boolean(selectedPosition && selectedPosition.openQuantity > 0);
-  const accountSummary = registeredAccount && auth.user ? auth.user.displayName : guestSession ? `${guestSession.walletID.slice(0, 8)}...` : "--";
+  const accountSummary = registeredAccount && auth.user ? auth.user.displayName : guestSession ? `${guestSession.walletID.slice(0, 8)}…` : "--";
   const lastPrice = candles.length > 0 ? candles[candles.length - 1].closePrice : null;
-  const chartRefreshLabel = isChartRefreshing ? "Refreshing..." : "Refresh now";
+  const chartRefreshLabel = isChartRefreshing ? "Refreshing…" : "Refresh Now";
 
   useEffect(() => {
     if (selectedStrategy) {
@@ -294,13 +307,13 @@ export function MarketDashboard({ detailOnly = false, initialMarket = "XRP/USDT"
   }
 
   return (
-    <main className="grid-glow min-h-screen overflow-hidden px-6 py-8 md:px-10 lg:px-14">
+    <main id="main-content" className="grid-glow min-h-screen overflow-hidden px-6 py-8 md:px-10 lg:px-14">
       <section className="mx-auto flex w-full max-w-7xl flex-col gap-8">
         <div className="rounded-[40px] border border-[var(--line)] bg-[var(--surface-strong)] p-6 shadow-[0_30px_90px_rgba(0,0,0,0.35)] backdrop-blur md:p-8">
           <div className="flex flex-col gap-8 lg:flex-row lg:items-start lg:justify-between">
             <div className="max-w-3xl">
-              {detailOnly ? <Link href="/" className="font-[var(--font-mono)] text-sm uppercase tracking-[0.32em] text-[var(--accent)]">Back to overview</Link> : <p className="font-[var(--font-mono)] text-sm uppercase tracking-[0.32em] text-[var(--accent)]">TradeLab Live Sandbox</p>}
-              <h1 className="mt-4 text-5xl font-semibold leading-none tracking-[-0.05em] md:text-7xl">{detailOnly ? selectedMarket : "Demo execution with real wallet movement."}</h1>
+              {detailOnly ? <Link href="/" className="focus-ring inline-flex rounded-full font-[var(--font-mono)] text-sm uppercase tracking-[0.32em] text-[var(--accent)] hover:text-[var(--text)]">Back to Overview</Link> : <p className="font-[var(--font-mono)] text-sm uppercase tracking-[0.32em] text-[var(--accent)]">TradeLab Live Sandbox</p>}
+              <h1 className="mt-4 text-5xl font-semibold leading-none tracking-[-0.05em] text-balance md:text-7xl">{detailOnly ? selectedMarket : "Demo execution with real wallet movement."}</h1>
               <p className="mt-6 max-w-2xl text-lg leading-8 text-[var(--muted)]">{detailOnly ? "Focused trading screen with chart, current position, buy and sell controls, and filtered history." : "Portfolio overview, accounting-mode selection, and fast navigation into market detail."}</p>
             </div>
             <div className="grid min-w-[320px] gap-4 rounded-[28px] border border-[var(--line)] bg-[rgba(7,17,31,0.78)] p-5 font-[var(--font-mono)] text-sm text-[var(--muted)]">
@@ -318,14 +331,14 @@ export function MarketDashboard({ detailOnly = false, initialMarket = "XRP/USDT"
 
           <div className="mt-6 flex flex-wrap gap-3">
             {(["average_cost", "fifo", "hybrid"] as AccountingMode[]).map((mode) => (
-              <button key={mode} type="button" onClick={() => setAccountingMode(mode)} className={`rounded-full border px-3 py-2 text-sm transition ${accountingMode === mode ? "border-[var(--accent)] bg-[rgba(110,242,211,0.1)] text-[var(--accent)]" : "border-[var(--line)] text-[var(--muted)]"}`}>
+              <button key={mode} type="button" onClick={() => setAccountingMode(mode)} className={`focus-ring rounded-full border px-3 py-2 text-sm transition-[border-color,background-color,color] ${accountingMode === mode ? "border-[var(--accent)] bg-[rgba(110,242,211,0.1)] text-[var(--accent)]" : "border-[var(--line)] text-[var(--muted)] hover:border-[var(--accent)] hover:text-[var(--text)]"}`}>
                 {accountingModeLabel(mode)}
               </button>
             ))}
           </div>
 
-          {error ? <div className="mt-6 rounded-2xl border border-[rgba(255,107,120,0.35)] bg-[rgba(255,107,120,0.08)] px-4 py-3 text-sm text-[var(--accent-hot)]">{error}</div> : null}
-          {success ? <div className="mt-6 rounded-2xl border border-[rgba(110,242,211,0.35)] bg-[rgba(110,242,211,0.08)] px-4 py-3 text-sm text-[var(--accent)]">{success}</div> : null}
+          {error ? <div role="status" aria-live="polite" className="mt-6 rounded-2xl border border-[rgba(255,107,120,0.35)] bg-[rgba(255,107,120,0.08)] px-4 py-3 text-sm text-[var(--accent-hot)]">{error}</div> : null}
+          {success ? <div role="status" aria-live="polite" className="mt-6 rounded-2xl border border-[rgba(110,242,211,0.35)] bg-[rgba(110,242,211,0.08)] px-4 py-3 text-sm text-[var(--accent)]">{success}</div> : null}
 
           {shouldShowAuthValuePrompt ? (
             <section className="mt-6 rounded-[28px] border border-[var(--line)] bg-[rgba(7,17,31,0.6)] p-5">
@@ -340,32 +353,32 @@ export function MarketDashboard({ detailOnly = false, initialMarket = "XRP/USDT"
             <section className="mt-6 rounded-[28px] border border-[rgba(110,242,211,0.28)] bg-[rgba(8,24,38,0.82)] p-5">
               <h2 className="text-2xl font-semibold">Keep your guest demo data or start fresh?</h2>
               <div className="mt-5 flex flex-wrap gap-3">
-                <button type="button" disabled={isUpgrading} onClick={() => void upgradeGuestSession(true)} className="rounded-full bg-[var(--accent)] px-4 py-2 text-sm font-semibold text-[#04111a] disabled:opacity-60">{isUpgrading ? "Upgrading..." : "Keep guest demo data"}</button>
-                <button type="button" disabled={isUpgrading} onClick={() => void upgradeGuestSession(false)} className="rounded-full border border-[var(--line)] px-4 py-2 text-sm font-medium text-[var(--text)] disabled:opacity-60">Start fresh</button>
+                <button type="button" disabled={isUpgrading} onClick={() => void upgradeGuestSession(true)} className="focus-ring rounded-full bg-[var(--accent)] px-4 py-2 text-sm font-semibold text-[#04111a] hover:brightness-105 disabled:opacity-60">{isUpgrading ? "Upgrading…" : "Keep guest demo data"}</button>
+                <button type="button" disabled={isUpgrading} onClick={() => void upgradeGuestSession(false)} className="focus-ring rounded-full border border-[var(--line)] px-4 py-2 text-sm font-medium text-[var(--text)] hover:border-[var(--accent)] hover:text-[var(--accent)] disabled:opacity-60">Start fresh</button>
               </div>
             </section>
           ) : null}
 
           <div className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-5">
-            <div className="rounded-2xl border border-[var(--line)] bg-[var(--surface)] px-4 py-4"><p className="font-[var(--font-mono)] text-xs uppercase tracking-[0.24em] text-[var(--muted)]">Cash balance</p><p className="mt-3 text-2xl font-semibold">{portfolio ? formatCurrency(portfolio.cashBalance ?? 0) : "--"}</p></div>
-            <div className="rounded-2xl border border-[var(--line)] bg-[var(--surface)] px-4 py-4"><p className="font-[var(--font-mono)] text-xs uppercase tracking-[0.24em] text-[var(--muted)]">Position value</p><p className="mt-3 text-2xl font-semibold">{portfolio ? formatCurrency(portfolio.positionValue ?? 0) : "--"}</p></div>
-            <div className="rounded-2xl border border-[var(--line)] bg-[var(--surface)] px-4 py-4"><p className="font-[var(--font-mono)] text-xs uppercase tracking-[0.24em] text-[var(--muted)]">Realized PnL</p><p className={`mt-3 text-2xl font-semibold ${portfolio ? pnlTone(portfolio.realizedPnL ?? 0) : ""}`}>{portfolio ? formatCurrency(portfolio.realizedPnL ?? 0) : "--"}</p></div>
-            <div className="rounded-2xl border border-[var(--line)] bg-[var(--surface)] px-4 py-4"><p className="font-[var(--font-mono)] text-xs uppercase tracking-[0.24em] text-[var(--muted)]">Unrealized PnL</p><p className={`mt-3 text-2xl font-semibold ${portfolio ? pnlTone(portfolio.unrealizedPnL ?? 0) : ""}`}>{portfolio ? formatCurrency(portfolio.unrealizedPnL ?? 0) : "--"}</p></div>
-            <div className="rounded-2xl border border-[var(--line)] bg-[var(--surface)] px-4 py-4"><p className="font-[var(--font-mono)] text-xs uppercase tracking-[0.24em] text-[var(--muted)]">Last price</p><p className="mt-3 text-2xl font-semibold">{lastPrice ? formatCurrency(lastPrice) : "--"}</p></div>
+            <div className="rounded-2xl border border-[var(--line)] bg-[var(--surface)] px-4 py-4"><p className="font-[var(--font-mono)] text-xs uppercase tracking-[0.24em] text-[var(--muted)]">Cash balance</p><p className="tabular-data mt-3 text-2xl font-semibold">{portfolio ? formatCurrency(portfolio.cashBalance ?? 0) : "--"}</p></div>
+            <div className="rounded-2xl border border-[var(--line)] bg-[var(--surface)] px-4 py-4"><p className="font-[var(--font-mono)] text-xs uppercase tracking-[0.24em] text-[var(--muted)]">Position value</p><p className="tabular-data mt-3 text-2xl font-semibold">{portfolio ? formatCurrency(portfolio.positionValue ?? 0) : "--"}</p></div>
+            <div className="rounded-2xl border border-[var(--line)] bg-[var(--surface)] px-4 py-4"><p className="font-[var(--font-mono)] text-xs uppercase tracking-[0.24em] text-[var(--muted)]">Realized PnL</p><p className={`tabular-data mt-3 text-2xl font-semibold ${portfolio ? pnlTone(portfolio.realizedPnL ?? 0) : ""}`}>{portfolio ? formatCurrency(portfolio.realizedPnL ?? 0) : "--"}</p></div>
+            <div className="rounded-2xl border border-[var(--line)] bg-[var(--surface)] px-4 py-4"><p className="font-[var(--font-mono)] text-xs uppercase tracking-[0.24em] text-[var(--muted)]">Unrealized PnL</p><p className={`tabular-data mt-3 text-2xl font-semibold ${portfolio ? pnlTone(portfolio.unrealizedPnL ?? 0) : ""}`}>{portfolio ? formatCurrency(portfolio.unrealizedPnL ?? 0) : "--"}</p></div>
+            <div className="rounded-2xl border border-[var(--line)] bg-[var(--surface)] px-4 py-4"><p className="font-[var(--font-mono)] text-xs uppercase tracking-[0.24em] text-[var(--muted)]">Last price</p><p className="tabular-data mt-3 text-2xl font-semibold">{lastPrice ? formatCurrency(lastPrice) : "--"}</p></div>
           </div>
 
           {!detailOnly ? (
             <section className="mt-6 rounded-[32px] border border-[var(--line)] bg-[var(--surface)] p-5 backdrop-blur">
               <div className="grid gap-3">
                 {markets.map((market) => (
-                  <Link key={market.id} href={`/markets/${encodeURIComponent(market.symbol)}`} className="rounded-[24px] border border-[var(--line)] bg-[rgba(7,17,31,0.45)] px-4 py-4 text-left transition hover:border-[var(--accent)]">
+                  <Link key={market.id} href={`/markets/${encodeURIComponent(market.symbol)}`} className="focus-ring rounded-[24px] border border-[var(--line)] bg-[rgba(7,17,31,0.45)] px-4 py-4 text-left transition-[border-color,transform] hover:border-[var(--accent)] hover:-translate-y-0.5">
                     <div className="flex items-center justify-between gap-4">
-                      <div><p className="text-lg font-semibold">{market.symbol}</p><p className="mt-1 text-sm text-[var(--muted)]">{market.baseAsset} priced in {market.quoteAsset}</p></div>
+                      <div className="min-w-0"><p className="text-lg font-semibold">{market.symbol}</p><p className="mt-1 text-sm text-[var(--muted)]">{market.baseAsset} priced in {market.quoteAsset}</p></div>
                       <div className="text-right">
                         <p className={`text-sm ${strategyStatusTone(availableStrategies.find((item) => item.marketSymbol === market.symbol)?.status ?? "draft")}`}>
                           {availableStrategies.find((item) => item.marketSymbol === market.symbol)?.status ?? "no automation"}
                         </p>
-                        <span className="text-sm text-[var(--accent)]">Open market detail</span>
+                        <span className="text-sm text-[var(--accent)]">Open Market Detail</span>
                       </div>
                     </div>
                   </Link>
@@ -373,8 +386,11 @@ export function MarketDashboard({ detailOnly = false, initialMarket = "XRP/USDT"
               </div>
               <form className="mt-6 grid gap-3 rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.45)] px-4 py-4" onSubmit={(event) => { event.preventDefault(); void submitOrder("buy"); }}>
                 <p className="text-lg font-semibold">Quick buy</p>
-                <input aria-label="Quick buy quote amount" value={buyQuoteAmount} onChange={(event) => setBuyQuoteAmount(event.target.value)} className="rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.6)] px-4 py-3 text-[var(--text)] outline-none" />
-                <button type="submit" disabled={isSubmitting || !activeWalletID} className="rounded-2xl bg-[var(--accent)] px-5 py-4 font-semibold text-[#04111a] disabled:opacity-60">{isSubmitting ? "Executing..." : "Run demo buy"}</button>
+                <label className="grid gap-2 text-sm text-[var(--muted)]" htmlFor="quick-buy-quote-amount">
+                  Quick buy amount (USDT)
+                  <input id="quick-buy-quote-amount" name="quick-buy-quote-amount" type="number" inputMode="decimal" step="any" autoComplete="off" value={buyQuoteAmount} onChange={(event) => setBuyQuoteAmount(event.target.value)} className={`${baseControlClassName} tabular-data`} />
+                </label>
+                <button type="submit" disabled={isSubmitting || !activeWalletID} className="focus-ring rounded-2xl bg-[var(--accent)] px-5 py-4 font-semibold text-[#04111a] hover:brightness-105 disabled:opacity-60">{isSubmitting ? "Executing…" : "Run Demo Buy"}</button>
               </form>
             </section>
           ) : null}
@@ -383,9 +399,12 @@ export function MarketDashboard({ detailOnly = false, initialMarket = "XRP/USDT"
             <div className="flex items-center justify-between gap-4">
               <h2 className="text-2xl font-semibold">{selectedMarket}</h2>
               {!detailOnly ? (
-                <select value={selectedMarket} onChange={(event) => setSelectedMarket(event.target.value)} className="rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.6)] px-4 py-3 text-[var(--text)] outline-none">
+                <label className="grid gap-2 text-sm text-[var(--muted)]">
+                  Active market
+                <select aria-label="Active market" name="active-market" value={selectedMarket} onChange={(event) => setSelectedMarket(event.target.value)} className={`${baseControlClassName} min-w-[13rem]`}>
                   {markets.map((market) => <option key={market.id} value={market.symbol}>{market.symbol}</option>)}
                 </select>
+                </label>
               ) : (
                 <button
                   type="button"
@@ -396,31 +415,31 @@ export function MarketDashboard({ detailOnly = false, initialMarket = "XRP/USDT"
                     });
                   }}
                   disabled={isChartRefreshing}
-                  className="rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.6)] px-4 py-3 text-sm font-medium text-[var(--text)] disabled:opacity-60"
+                  className={secondaryButtonClassName}
                 >
                   {chartRefreshLabel}
                 </button>
               )}
             </div>
             <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
-              <div className="flex flex-wrap gap-3">{["15m", "1h", "4h"].map((interval) => <button key={interval} type="button" onClick={() => setSelectedInterval(interval)} className={`rounded-full border px-3 py-2 text-sm ${selectedInterval === interval ? "border-[var(--accent)] bg-[rgba(110,242,211,0.1)] text-[var(--accent)]" : "border-[var(--line)]"}`}>{interval}</button>)}</div>
+              <div className="flex flex-wrap gap-3">{["15m", "1h", "4h"].map((interval) => <button key={interval} type="button" onClick={() => setSelectedInterval(interval)} className={`focus-ring rounded-full border px-3 py-2 text-sm transition-[border-color,background-color,color] ${selectedInterval === interval ? "border-[var(--accent)] bg-[rgba(110,242,211,0.1)] text-[var(--accent)]" : "border-[var(--line)] text-[var(--muted)] hover:border-[var(--accent)] hover:text-[var(--text)]"}`}>{interval}</button>)}</div>
               <div className="flex flex-wrap items-center gap-3 text-sm text-[var(--muted)]">
                 <span className="rounded-full border border-[var(--line)] px-3 py-2">Feed {chartMeta?.source === "stale" ? "stale fallback" : "fresh"}</span>
                 {chartMeta ? <span className="rounded-full border border-[var(--line)] px-3 py-2">Updated {formatFeedTime(chartMeta.generatedAt)}</span> : null}
-                {detailOnly ? <span className="rounded-full border border-[var(--line)] px-3 py-2">{isChartRefreshing ? "Refreshing..." : `Auto ${Math.floor(CHART_AUTO_REFRESH_MS / 1000)}s`}</span> : null}
+                {detailOnly ? <span className="rounded-full border border-[var(--line)] px-3 py-2">{isChartRefreshing ? "Refreshing…" : `Auto ${Math.floor(CHART_AUTO_REFRESH_MS / 1000)}s`}</span> : null}
               </div>
             </div>
             <div className="mt-6">
               {isChartLoading && candles.length === 0 ? (
-                <div className="rounded-2xl border border-dashed border-[var(--line)] px-4 py-12 text-sm text-[var(--muted)]">Loading candle data...</div>
+                <div className="rounded-2xl border border-dashed border-[var(--line)] px-4 py-12 text-sm text-[var(--muted)]">Loading candle data…</div>
               ) : chartError && candles.length === 0 ? (
-                <div className="rounded-2xl border border-[rgba(255,107,120,0.35)] bg-[rgba(255,107,120,0.08)] px-4 py-12 text-sm text-[var(--accent-hot)]">{chartError}</div>
+                <div role="status" aria-live="polite" className="rounded-2xl border border-[rgba(255,107,120,0.35)] bg-[rgba(255,107,120,0.08)] px-4 py-12 text-sm text-[var(--accent-hot)]">{chartError}</div>
               ) : (
                 <CandleChart candles={candles} />
               )}
             </div>
             {chartError && candles.length > 0 ? (
-              <div className="mt-4 rounded-2xl border border-[rgba(255,107,120,0.35)] bg-[rgba(255,107,120,0.08)] px-4 py-4 text-sm text-[var(--accent-hot)]">
+              <div role="status" aria-live="polite" className="mt-4 rounded-2xl border border-[rgba(255,107,120,0.35)] bg-[rgba(255,107,120,0.08)] px-4 py-4 text-sm text-[var(--accent-hot)]">
                 {chartError}
               </div>
             ) : null}
@@ -435,29 +454,29 @@ export function MarketDashboard({ detailOnly = false, initialMarket = "XRP/USDT"
                     <label className="rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.45)] p-4">
                       <div className="flex items-center justify-between gap-3">
                         <span className="text-sm font-semibold">Dip buy</span>
-                        <input type="checkbox" checked={strategyConfig.dipBuy.enabled} onChange={(event) => setStrategyConfig((current) => ({ ...current, dipBuy: { ...current.dipBuy, enabled: event.target.checked } }))} />
+                        <input aria-label="Enable dip-buy rule" type="checkbox" checked={strategyConfig.dipBuy.enabled} onChange={(event) => setStrategyConfig((current) => ({ ...current, dipBuy: { ...current.dipBuy, enabled: event.target.checked } }))} />
                       </div>
                       <div className="mt-3 grid gap-3">
-                        <input value={strategyConfig.dipBuy.dipPercent} onChange={(event) => setStrategyConfig((current) => ({ ...current, dipBuy: { ...current.dipBuy, dipPercent: Number(event.target.value) } }))} className="rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.6)] px-4 py-3 text-[var(--text)] outline-none" />
-                        <input value={strategyConfig.dipBuy.spendQuoteAmount} onChange={(event) => setStrategyConfig((current) => ({ ...current, dipBuy: { ...current.dipBuy, spendQuoteAmount: Number(event.target.value) } }))} className="rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.6)] px-4 py-3 text-[var(--text)] outline-none" />
+                        <span className="grid gap-2 text-sm text-[var(--muted)]">Dip threshold (%)<input name="dip-buy-percent" type="number" inputMode="decimal" step="any" autoComplete="off" value={strategyConfig.dipBuy.dipPercent} onChange={(event) => setStrategyConfig((current) => ({ ...current, dipBuy: { ...current.dipBuy, dipPercent: Number(event.target.value) } }))} className={`${baseControlClassName} tabular-data`} /></span>
+                        <span className="grid gap-2 text-sm text-[var(--muted)]">Spend amount (USDT)<input name="dip-buy-spend" type="number" inputMode="decimal" step="any" autoComplete="off" value={strategyConfig.dipBuy.spendQuoteAmount} onChange={(event) => setStrategyConfig((current) => ({ ...current, dipBuy: { ...current.dipBuy, spendQuoteAmount: Number(event.target.value) } }))} className={`${baseControlClassName} tabular-data`} /></span>
                       </div>
                     </label>
                     <label className="rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.45)] p-4">
                       <div className="flex items-center justify-between gap-3">
                         <span className="text-sm font-semibold">Take profit</span>
-                        <input type="checkbox" checked={strategyConfig.takeProfit.enabled} onChange={(event) => setStrategyConfig((current) => ({ ...current, takeProfit: { ...current.takeProfit, enabled: event.target.checked } }))} />
+                        <input aria-label="Enable take-profit rule" type="checkbox" checked={strategyConfig.takeProfit.enabled} onChange={(event) => setStrategyConfig((current) => ({ ...current, takeProfit: { ...current.takeProfit, enabled: event.target.checked } }))} />
                       </div>
                       <div className="mt-3 grid gap-3">
-                        <input value={strategyConfig.takeProfit.triggerPercent} onChange={(event) => setStrategyConfig((current) => ({ ...current, takeProfit: { ...current.takeProfit, triggerPercent: Number(event.target.value) } }))} className="rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.6)] px-4 py-3 text-[var(--text)] outline-none" />
+                        <span className="grid gap-2 text-sm text-[var(--muted)]">Target gain (%)<input name="take-profit-percent" type="number" inputMode="decimal" step="any" autoComplete="off" value={strategyConfig.takeProfit.triggerPercent} onChange={(event) => setStrategyConfig((current) => ({ ...current, takeProfit: { ...current.takeProfit, triggerPercent: Number(event.target.value) } }))} className={`${baseControlClassName} tabular-data`} /></span>
                       </div>
                     </label>
                     <label className="rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.45)] p-4">
                       <div className="flex items-center justify-between gap-3">
                         <span className="text-sm font-semibold">Stop loss</span>
-                        <input type="checkbox" checked={strategyConfig.stopLoss.enabled} onChange={(event) => setStrategyConfig((current) => ({ ...current, stopLoss: { ...current.stopLoss, enabled: event.target.checked } }))} />
+                        <input aria-label="Enable stop-loss rule" type="checkbox" checked={strategyConfig.stopLoss.enabled} onChange={(event) => setStrategyConfig((current) => ({ ...current, stopLoss: { ...current.stopLoss, enabled: event.target.checked } }))} />
                       </div>
                       <div className="mt-3 grid gap-3">
-                        <input value={strategyConfig.stopLoss.triggerPercent} onChange={(event) => setStrategyConfig((current) => ({ ...current, stopLoss: { ...current.stopLoss, triggerPercent: Number(event.target.value) } }))} className="rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.6)] px-4 py-3 text-[var(--text)] outline-none" />
+                        <span className="grid gap-2 text-sm text-[var(--muted)]">Stop threshold (%)<input name="stop-loss-percent" type="number" inputMode="decimal" step="any" autoComplete="off" value={strategyConfig.stopLoss.triggerPercent} onChange={(event) => setStrategyConfig((current) => ({ ...current, stopLoss: { ...current.stopLoss, triggerPercent: Number(event.target.value) } }))} className={`${baseControlClassName} tabular-data`} /></span>
                       </div>
                     </label>
                   </div>
@@ -469,13 +488,13 @@ export function MarketDashboard({ detailOnly = false, initialMarket = "XRP/USDT"
                     <div className="mt-4 grid gap-2 text-sm text-[var(--muted)]">
                       <span>Last decision: {selectedStrategy?.lastDecision || "--"}</span>
                       <span>Last outcome: {selectedStrategy?.lastOutcome || "--"}</span>
-                      <span>Reference price: {selectedStrategy?.referencePrice ? formatCurrency(selectedStrategy.referencePrice) : "--"}</span>
+                      <span className="tabular-data">Reference price: {selectedStrategy?.referencePrice ? formatCurrency(selectedStrategy.referencePrice) : "--"}</span>
                     </div>
                     <p className="mt-4 text-sm leading-7 text-[var(--muted)]">{selectedStrategy?.lastReason || "No evaluation yet. Save and activate automation to start the strategy loop."}</p>
                     <div className="mt-5 flex flex-wrap gap-3">
-                      <button type="button" onClick={() => void persistStrategy(selectedStrategy?.status === "active" ? "active" : "draft")} disabled={isSavingStrategy} className="rounded-2xl border border-[var(--line)] px-4 py-3 text-sm font-medium text-[var(--text)] disabled:opacity-60">{isSavingStrategy ? "Saving..." : "Save bundle"}</button>
-                      <button type="button" onClick={() => void persistStrategy("active")} disabled={isSavingStrategy} className="rounded-2xl bg-[var(--accent)] px-4 py-3 text-sm font-semibold text-[#04111a] disabled:opacity-60">Activate</button>
-                      <button type="button" onClick={() => void persistStrategy("paused")} disabled={isSavingStrategy || !selectedStrategy} className="rounded-2xl bg-[var(--accent-warm)] px-4 py-3 text-sm font-semibold text-[#04111a] disabled:opacity-60">Pause</button>
+                      <button type="button" onClick={() => void persistStrategy(selectedStrategy?.status === "active" ? "active" : "draft")} disabled={isSavingStrategy} className={secondaryButtonClassName}>{isSavingStrategy ? "Saving…" : "Save bundle"}</button>
+                      <button type="button" onClick={() => void persistStrategy("active")} disabled={isSavingStrategy} className={accentButtonClassName}>Activate</button>
+                      <button type="button" onClick={() => void persistStrategy("paused")} disabled={isSavingStrategy || !selectedStrategy} className={warmButtonClassName}>Pause</button>
                     </div>
                   </div>
                 </div>
@@ -487,15 +506,21 @@ export function MarketDashboard({ detailOnly = false, initialMarket = "XRP/USDT"
                 <div className="mt-5 grid gap-4 md:grid-cols-2">
                   <form className="grid gap-3 rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.45)] px-4 py-4" onSubmit={(event) => { event.preventDefault(); void submitOrder("buy"); }}>
                     <p className="text-lg font-semibold">Buy {selectedMarket}</p>
-                    <input aria-label="Buy quote amount" value={buyQuoteAmount} onChange={(event) => setBuyQuoteAmount(event.target.value)} className="rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.6)] px-4 py-3 text-[var(--text)] outline-none" />
-                    <button type="submit" disabled={isSubmitting || !activeWalletID} className="rounded-2xl bg-[var(--accent)] px-5 py-4 font-semibold text-[#04111a] disabled:opacity-60">{isSubmitting ? "Executing..." : "Run demo buy"}</button>
+                    <label className="grid gap-2 text-sm text-[var(--muted)]" htmlFor="detail-buy-quote-amount">
+                      Buy amount (USDT)
+                      <input id="detail-buy-quote-amount" name="detail-buy-quote-amount" aria-label="Buy quote amount" type="number" inputMode="decimal" step="any" autoComplete="off" value={buyQuoteAmount} onChange={(event) => setBuyQuoteAmount(event.target.value)} className={`${baseControlClassName} tabular-data`} />
+                    </label>
+                    <button type="submit" disabled={isSubmitting || !activeWalletID} className={accentButtonClassName}>{isSubmitting ? "Executing…" : "Run Demo Buy"}</button>
                   </form>
                   <form className="grid gap-3 rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.45)] px-4 py-4" onSubmit={(event) => { event.preventDefault(); void submitOrder("sell"); }}>
                     <p className="text-lg font-semibold">Sell {selectedMarket}</p>
-                    <input aria-label="Sell quantity" value={sellBaseQuantity} onChange={(event) => {
+                    <label className="grid gap-2 text-sm text-[var(--muted)]" htmlFor="detail-sell-quantity">
+                      Sell quantity ({selectedPosition?.baseAsset ?? "base"})
+                    <input id="detail-sell-quantity" name="detail-sell-quantity" aria-label="Sell quantity" type="number" inputMode="decimal" step="any" autoComplete="off" value={sellBaseQuantity} onChange={(event) => {
                       sellBaseQuantityRef.current = event.target.value;
                       setSellBaseQuantity(event.target.value);
-                    }} className="rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.6)] px-4 py-3 text-[var(--text)] outline-none" />
+                    }} className={`${baseControlClassName} tabular-data`} />
+                    </label>
                     <button type="button" onClick={() => {
                       if (!selectedPosition) {
                         return;
@@ -504,12 +529,12 @@ export function MarketDashboard({ detailOnly = false, initialMarket = "XRP/USDT"
                       const nextQuantity = String(selectedPosition.openQuantity);
                       sellBaseQuantityRef.current = nextQuantity;
                       setSellBaseQuantity(nextQuantity);
-                    }} disabled={!canUseMaxSell} className="rounded-2xl border border-[var(--line)] px-4 py-3 text-sm font-medium text-[var(--muted)] disabled:cursor-not-allowed disabled:opacity-50">Max position</button>
-                    <button type="submit" disabled={isSubmitting || !activeWalletID || !selectedPosition} className="rounded-2xl bg-[var(--accent-warm)] px-5 py-4 font-semibold text-[#04111a] disabled:opacity-60">{isSubmitting ? "Executing..." : "Run demo sell"}</button>
+                    }} disabled={!canUseMaxSell} className={secondaryButtonClassName}>Max position</button>
+                    <button type="submit" disabled={isSubmitting || !activeWalletID || !selectedPosition} className={warmButtonClassName}>{isSubmitting ? "Executing…" : "Run Demo Sell"}</button>
                   </form>
                 </div>
               ) : (
-                <div className="mt-5 grid gap-3">{portfolio?.balances.map((balance) => <div key={balance.assetSymbol} className="flex items-center justify-between rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.45)] px-4 py-4"><span className="font-medium">{balance.assetSymbol}</span><span className="font-[var(--font-mono)] text-[var(--muted)]">{formatNumber(balance.available)}</span></div>)}</div>
+                <div className="mt-5 grid gap-3">{portfolio?.balances.length ? portfolio.balances.map((balance) => <div key={balance.assetSymbol} className="flex items-center justify-between rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.45)] px-4 py-4"><span className="font-medium">{balance.assetSymbol}</span><span className="tabular-data font-[var(--font-mono)] text-[var(--muted)]">{formatNumber(balance.available)}</span></div>) : <EmptyPanelState>Balances will appear here as soon as the session portfolio is available.</EmptyPanelState>}</div>
               )}
             </section>
 
@@ -520,16 +545,16 @@ export function MarketDashboard({ detailOnly = false, initialMarket = "XRP/USDT"
                   (detailOnly ? (selectedPosition ? [selectedPosition] : []) : portfolio?.positions ?? []).map((position) => (
                     <div key={position.marketSymbol} className="rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.45)] px-4 py-4">
                       <div className="flex items-center justify-between gap-4"><span className="text-lg font-semibold">{position.marketSymbol}</span><span className="text-sm text-[var(--accent)]">{formatCurrency(position.positionValue)}</span></div>
-                      <p className="mt-2 text-sm text-[var(--muted)]">Open qty {formatNumber(position.openQuantity)} at avg {formatCurrency(position.entryPriceAvg)}</p>
+                      <p className="tabular-data mt-2 text-sm text-[var(--muted)]">Open qty {formatNumber(position.openQuantity)} at avg {formatCurrency(position.entryPriceAvg)}</p>
                       <div className="mt-3 grid gap-2 text-sm text-[var(--muted)] md:grid-cols-2">
-                        <span>Cost basis {formatCurrency(position.costBasisValue)}</span>
-                        <span>Current {formatCurrency(position.currentPrice)}</span>
-                        <span className={pnlTone(position.realizedPnL)}>Realized {formatCurrency(position.realizedPnL)}</span>
-                        <span className={pnlTone(position.unrealizedPnL)}>Unrealized {formatCurrency(position.unrealizedPnL)}</span>
+                        <span className="tabular-data">Cost basis {formatCurrency(position.costBasisValue)}</span>
+                        <span className="tabular-data">Current {formatCurrency(position.currentPrice)}</span>
+                        <span className={`tabular-data ${pnlTone(position.realizedPnL)}`}>Realized {formatCurrency(position.realizedPnL)}</span>
+                        <span className={`tabular-data ${pnlTone(position.unrealizedPnL)}`}>Unrealized {formatCurrency(position.unrealizedPnL)}</span>
                       </div>
                     </div>
                   ))
-                ) : <div className="rounded-2xl border border-dashed border-[var(--line)] px-4 py-6 text-sm text-[var(--muted)]">No open positions yet.</div>}
+                ) : <EmptyPanelState>No open positions yet.</EmptyPanelState>}
               </div>
             </section>
 
@@ -539,23 +564,23 @@ export function MarketDashboard({ detailOnly = false, initialMarket = "XRP/USDT"
                 {visibleOrders.length ? visibleOrders.map((order) => (
                   <div key={order.id} className="rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.45)] px-4 py-4">
                     <div className="flex items-center justify-between gap-4"><span className="text-lg font-semibold">{order.marketSymbol}</span><span className={order.side === "sell" ? "text-[var(--accent-warm)]" : "text-[var(--accent)]"}>{order.side}</span></div>
-                    <p className="mt-2 text-sm text-[var(--muted)]">{formatNumber(order.baseQuantity)} units at {formatCurrency(order.expectedPrice)}</p>
-                    <div className="mt-3 flex flex-wrap gap-3 text-sm text-[var(--muted)]"><span>Quote {formatCurrency(order.quoteAmount)}</span><span>After trade {formatNumber(order.positionAfter)}</span><span>{order.orderSource === "strategy" ? "Automated" : "Manual"}</span>{order.side === "sell" ? <span className={pnlTone(order.realizedPnL)}>Realized {formatCurrency(order.realizedPnL)}</span> : null}</div>
+                    <p className="tabular-data mt-2 text-sm text-[var(--muted)]">{formatNumber(order.baseQuantity)} units at {formatCurrency(order.expectedPrice)}</p>
+                    <div className="mt-3 flex flex-wrap gap-3 text-sm text-[var(--muted)]"><span className="tabular-data">Quote {formatCurrency(order.quoteAmount)}</span><span className="tabular-data">After trade {formatNumber(order.positionAfter)}</span><span>{order.orderSource === "strategy" ? "Automated" : "Manual"}</span>{order.side === "sell" ? <span className={`tabular-data ${pnlTone(order.realizedPnL)}`}>Realized {formatCurrency(order.realizedPnL)}</span> : null}</div>
                   </div>
-                )) : <div className="rounded-2xl border border-dashed border-[var(--line)] px-4 py-6 text-sm text-[var(--muted)]">No orders yet for this scope.</div>}
+                )) : <EmptyPanelState>No orders yet for this scope.</EmptyPanelState>}
               </div>
             </section>
 
             <section className="rounded-[32px] border border-[var(--line)] bg-[var(--surface)] p-5 backdrop-blur">
               <p className="font-[var(--font-mono)] text-xs uppercase tracking-[0.28em] text-[var(--muted)]">{detailOnly ? "Selected market activity" : "Activity log"}</p>
               <div className="mt-5 grid gap-3">
-                {activityError ? <div className="rounded-2xl border border-[rgba(255,107,120,0.35)] bg-[rgba(255,107,120,0.08)] px-4 py-4 text-sm text-[var(--accent-hot)]">{activityError}</div> : null}
+                {activityError ? <div role="status" aria-live="polite" className="rounded-2xl border border-[rgba(255,107,120,0.35)] bg-[rgba(255,107,120,0.08)] px-4 py-4 text-sm text-[var(--accent-hot)]">{activityError}</div> : null}
                 {visibleActivity.length ? visibleActivity.map((item) => (
                   <div key={item.id} className="rounded-2xl border border-[var(--line)] bg-[rgba(7,17,31,0.45)] px-4 py-4">
                     <div className="flex items-center justify-between gap-4"><span className="text-lg font-semibold">{item.title}</span><span className="text-sm uppercase text-[var(--accent-hot)]">{item.logType}</span></div>
                     <p className="mt-2 text-sm text-[var(--muted)]">{item.message}</p>
                   </div>
-                )) : activityError ? null : <div className="rounded-2xl border border-dashed border-[var(--line)] px-4 py-6 text-sm text-[var(--muted)]">Activity will populate as soon as trades are executed for this scope.</div>}
+                )) : activityError ? null : <EmptyPanelState>Activity will populate as soon as trades are executed for this scope.</EmptyPanelState>}
               </div>
             </section>
           </div>


### PR DESCRIPTION
## Summary
- add explicit trade-field labels, input metadata, and visible focus states across the trading surface
- tighten empty and async status states for chart, balances, orders, and activity panels
- improve number readability and trading-oriented UI density without changing product behavior

## Testing
- npm run test
- npm run build
- npm run test:e2e

Closes #95