### PR TITLE
Unblock production sync from stale release manifests

### DIFF
--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -55,22 +55,12 @@ jobs:
           release_tag = os.environ["RELEASE_TAG"]
           prod_file = Path("deploy/infrastructure/applications/tradelab-prod.yaml")
           lines = []
-          in_source = False
           in_kustomize = False
           backend_image = f"ghcr.io/aidun/tradelab-backend:{release_tag}"
           frontend_image = f"ghcr.io/aidun/tradelab-frontend:{release_tag}"
           for line in prod_file.read_text(encoding="utf-8").splitlines():
             stripped = line.strip()
-            if stripped == "source:":
-              in_source = True
-            elif in_source and line.startswith("  ") and not line.startswith("    "):
-              in_source = False
-
-            if in_source and stripped.startswith("targetRevision:"):
-              lines.append(f"    targetRevision: {release_tag}")
-              continue
-
-            if in_source and stripped == "kustomize:":
+            if stripped == "    kustomize:" or stripped == "kustomize:":
               in_kustomize = True
               lines.append(line)
               continue

--- a/deploy/infrastructure/applications/tradelab-prod.yaml
+++ b/deploy/infrastructure/applications/tradelab-prod.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/aidun/tradelab.git
-    targetRevision: v0.1.22
+    targetRevision: master
     path: deploy/kubernetes/overlays/production
     kustomize:
       images:

--- a/docs/ai-metadata.json
+++ b/docs/ai-metadata.json
@@ -222,7 +222,7 @@
         "conditions": [
           "requested release tag exists as an official GitHub release or the latest release is resolved automatically"
         ],
-        "action": "Update the always-present production Argo CD application to the selected official release tag on master"
+        "action": "Update the always-present production Argo CD application on master to the selected official release image tags"
       }
     ],
     "observability": [

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -224,9 +224,9 @@ The release workflow is started manually from `master` and runs in this order:
 
 The production promotion workflow is also manual.
 
-It resolves the requested or latest official GitHub release and updates the production Argo CD application to that release tag.
+It resolves the requested or latest official GitHub release and updates the production Argo CD application to that release image pair.
 
-`tradelab-prod` stays in the Argo root application set at all times. The manual workflow only advances its release target.
+`tradelab-prod` stays in the Argo root application set at all times. It always renders the current `master` deployment manifests, and the manual workflow only advances the pinned release image tags.
 
 ### Publish Master Images
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -52,12 +52,12 @@ TradeLab publishes two image classes:
   - `latest`
   - `v0.1.<run-number>`
 
-`tradelab-dev` should use immutable `master-<shortsha>` image tags through its Argo CD application manifest. `tradelab-prod` should use immutable official release tags or the packaged manifest artifact.
+`tradelab-dev` should use immutable `master-<shortsha>` image tags through its Argo CD application manifest. `tradelab-prod` should use immutable official release tags while rendering the current production manifests from `master`.
 
 ## Environment policy
 
 - `tradelab-dev` always follows `master`
-- `tradelab-prod` is promoted only to an official GitHub release tag
+- `tradelab-prod` is promoted only to official GitHub release image tags
 - production promotion is handled by the `Promote Production` workflow, which updates the always-present Argo CD production application to the selected or latest published release
 
 ## What a release signals

--- a/docs/system-operations.md
+++ b/docs/system-operations.md
@@ -177,7 +177,7 @@ It:
 2. updates [tradelab-prod.yaml](../deploy/infrastructure/applications/tradelab-prod.yaml)
 3. commits the promotion change back to `master`
 
-`tradelab-prod` is always part of the Argo CD root application set. Production promotion only moves its target release; it does not create the application for the first time.
+`tradelab-prod` is always part of the Argo CD root application set. It always renders the current `master` deployment manifests, while the promotion workflow only advances the pinned backend and frontend image tags to the selected official release. That keeps production on released artifacts without depending on older tagged manifest trees.
 
 This means the effective repository delivery path is:
 


### PR DESCRIPTION
## Summary
- keep 	radelab-prod on the current master manifest tree
- make production promotion update only the pinned release image tags
- align the release and operations docs with the release-image-based production model

Closes #125

## Verification
- C:\\Users\\marku\\bin\\kubectl.exe kustomize deploy\\infrastructure\\applications
- PowerShell JSON parse for docs\\ai-metadata.json
- git diff --check