### PR TITLE
Ignore MetalLB CRD caBundle drift

### DIFF
--- a/deploy/infrastructure/applications/metallb.yaml
+++ b/deploy/infrastructure/applications/metallb.yaml
@@ -7,6 +7,12 @@ metadata:
     argocd.argoproj.io/sync-wave: "1"
 spec:
   project: default
+  ignoreDifferences:
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: bgppeers.metallb.io
+      jsonPointers:
+        - /spec/conversion/webhook/clientConfig/caBundle
   sources:
     - repoURL: https://metallb.github.io/metallb
       chart: metallb


### PR DESCRIPTION
## Summary
- ignore the mutable webhook caBundle field on gppeers.metallb.io
- keep the MetalLB app scoped to a narrow CRD-only Argo drift fix

Closes #129

## Verification
- C:\\Users\\marku\\bin\\kubectl.exe kustomize deploy\\infrastructure\\applications
- git diff --check