### PR TITLE
Add release branches for production promotions

### DIFF
--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release_tag: ${{ steps.resolve.outputs.release_tag }}
+      release_branch: ${{ steps.resolve.outputs.release_branch }}
 
     steps:
       - name: Resolve release tag
@@ -31,6 +32,7 @@ jobs:
             gh release view "$tag" --json tagName --jq '.tagName' >/dev/null
           fi
           echo "release_tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "release_branch=release/$tag" >> "$GITHUB_OUTPUT"
 
   promote-production:
     name: Update production Argo target
@@ -48,18 +50,31 @@ jobs:
         shell: python
         env:
           RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
+          RELEASE_BRANCH: ${{ needs.resolve-release.outputs.release_branch }}
         run: |
           from pathlib import Path
           import os
 
           release_tag = os.environ["RELEASE_TAG"]
+          release_branch = os.environ["RELEASE_BRANCH"]
           prod_file = Path("deploy/infrastructure/applications/tradelab-prod.yaml")
           lines = []
+          in_source = False
           in_kustomize = False
           backend_image = f"ghcr.io/aidun/tradelab-backend:{release_tag}"
           frontend_image = f"ghcr.io/aidun/tradelab-frontend:{release_tag}"
           for line in prod_file.read_text(encoding="utf-8").splitlines():
             stripped = line.strip()
+            if stripped == "source:":
+              in_source = True
+              lines.append(line)
+              continue
+
+            if in_source and stripped.startswith("targetRevision:"):
+              prefix = line.split("targetRevision:")[0]
+              lines.append(f"{prefix}targetRevision: {release_branch}")
+              continue
+
             if stripped == "    kustomize:" or stripped == "kustomize:":
               in_kustomize = True
               lines.append(line)
@@ -75,6 +90,8 @@ jobs:
 
             if in_kustomize and line.startswith("  ") and not line.startswith("      "):
               in_kustomize = False
+            if in_source and line.startswith("  ") and not line.startswith("    "):
+              in_source = False
 
             lines.append(line)
 
@@ -86,7 +103,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add deploy/infrastructure/applications/tradelab-prod.yaml
           if git diff --cached --quiet; then
-            echo "Production already points at the requested release tag."
+            echo "Production already points at the requested release branch and image tags."
             exit 0
           fi
           git commit -m "Promote production to ${{ needs.resolve-release.outputs.release_tag }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
       name: ${{ steps.meta.outputs.name }}
       source_ref: ${{ steps.meta.outputs.source_ref }}
       branch_name: ${{ steps.meta.outputs.branch_name }}
+      release_branch: ${{ steps.meta.outputs.release_branch }}
       source_commit: ${{ steps.commit.outputs.source_commit }}
 
     steps:
@@ -45,6 +46,7 @@ jobs:
           echo "source_ref=${{ inputs.source_ref }}" >> "$GITHUB_OUTPUT"
           branch_name="${{ inputs.source_ref }}"
           echo "branch_name=${branch_name#refs/heads/}" >> "$GITHUB_OUTPUT"
+          echo "release_branch=release/$tag" >> "$GITHUB_OUTPUT"
 
       - name: Resolve source commit
         id: commit
@@ -341,3 +343,21 @@ jobs:
             dist/tradelab-api-windows-amd64.exe
             dist/tradelab-frontend-standalone.tar.gz
             dist/tradelab-kubernetes.tar.gz
+
+  publish-release-branch:
+    name: Publish release branch
+    needs:
+      - release-metadata
+      - create-release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out release source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-metadata.outputs.source_ref }}
+          fetch-depth: 0
+
+      - name: Publish release branch
+        run: |
+          git push origin HEAD:refs/heads/${{ needs.release-metadata.outputs.release_branch }}

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ It helps teams and individual builders:
 - product-facing backtest reporting with summary cards, an equity curve, and recent-run comparison
 - market candle rendering with bounded stale-feed fallback behavior
 - Kubernetes deployment assets, repo-managed Traefik and MetalLB bootstrap, generated first-run database credentials, CI validation, and release automation
-- GitOps environment promotion with deterministic `dev -> master commit image` and `prod -> official release tag`
+- GitOps environment promotion with deterministic `dev -> master commit image` and `prod -> official release branch plus tag`
 
 ## Product walkthrough
 
@@ -84,7 +84,7 @@ TradeLab is maintained with a product-style engineering workflow:
 - frontend end-to-end coverage via Playwright
 - container build validation for backend and frontend
 - Kubernetes manifest rendering validation
-- automated PR validation, immutable master-image publication for development, squash merges, manual release execution, and explicit production promotion
+- automated PR validation, immutable master-image publication for development, squash merges, manual release execution with release-branch publication, and explicit production promotion
 
 For the exact PR -> CI -> merge -> release sequence, see:
 

--- a/deploy/infrastructure/applications/tradelab-prod.yaml
+++ b/deploy/infrastructure/applications/tradelab-prod.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/aidun/tradelab.git
-    targetRevision: master
+    targetRevision: release/v0.1.22
     path: deploy/kubernetes/overlays/production
     kustomize:
       images:

--- a/docs/ai-metadata.json
+++ b/docs/ai-metadata.json
@@ -59,8 +59,8 @@
     "structured backend request and service logging",
     "PR-first CI validation",
     "automatic master-image publication for development after merges to master",
-    "manual GitHub release execution from master",
-    "manual production promotion to the latest official release tag",
+    "manual GitHub release execution from master with matching release-branch publication",
+    "manual production promotion to the latest official release branch and tag pair",
     "k3s platform bootstrap with Argo CD app-of-apps",
     "repo-managed MetalLB and Traefik platform synchronization",
     "immutable release manifest rendering"
@@ -213,7 +213,8 @@
           "Verify backend and Verify frontend",
           "Build backend binaries, Build frontend artifact, Publish backend image, and Publish frontend image",
           "Package Kubernetes manifests",
-          "Create GitHub release"
+          "Create GitHub release",
+          "Publish matching release/<tag> branch"
         ]
       },
       {
@@ -222,7 +223,7 @@
         "conditions": [
           "requested release tag exists as an official GitHub release or the latest release is resolved automatically"
         ],
-        "action": "Update the always-present production Argo CD application on master to the selected official release image tags"
+        "action": "Update the always-present production Argo CD application on master to the selected official release branch plus matching image tags"
       }
     ],
     "observability": [
@@ -271,7 +272,7 @@
       ],
       "environment_revision_policy": {
         "development": "track the latest merged master commit through an Argo application manifest committed on master, with Publish Master Images either creating the update PR automatically or surfacing a compare URL when repository policy blocks Actions PR creation",
-        "production": "track a promoted official release tag"
+        "production": "track a promoted official release branch plus matching immutable release image tags"
       }
     }
   },

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -28,7 +28,7 @@ Every successful official release publishes:
 - `ghcr.io/aidun/tradelab-frontend:latest`
 - `ghcr.io/aidun/tradelab-frontend:v0.1.<run-number>`
 
-Argo CD development now deploys immutable `master-<shortsha>` image tags that are committed back into the development application manifest after each successful `master` image publish. Release deployments should use the packaged manifest artifact or the production Argo CD application pinned to an official release tag.
+Argo CD development now deploys immutable `master-<shortsha>` image tags that are committed back into the development application manifest after each successful `master` image publish. Release deployments should use the packaged manifest artifact or the production Argo CD application pinned to the matching official `release/<tag>` branch and release image tags.
 
 ## Layout
 
@@ -235,7 +235,7 @@ After apply, validate the first protected product flow with [installation-valida
 Production image policy:
 
 - the production Argo CD application always uses release-tagged backend and frontend images
-- the `Promote Production` workflow updates both the Argo source revision and the production image tags together
+- the `Promote Production` workflow updates both the Argo source revision to `release/<tag>` and the production image tags together
 - production should never depend on mutable `master` or `latest` tags
 
 ## Operational notes

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -166,7 +166,7 @@ TradeLab currently follows a PR-first workflow:
 - merges are expected to remain reviewable and reasonably scoped
 - `master` is the integration branch for development and release preparation
 - official releases are triggered manually from GitHub Actions
-- production promotion is a separate manual workflow that moves Argo CD to an official release tag
+- production promotion is a separate manual workflow that moves Argo CD to an official `release/<tag>` branch plus matching release image tags
 
 ## GitHub Actions flow
 
@@ -219,6 +219,7 @@ The release workflow is started manually from `master` and runs in this order:
 3. `Build backend binaries`, `Build frontend artifact`, `Publish backend image`, and `Publish frontend image`
 4. `Package Kubernetes manifests`
 5. `Create GitHub release`
+6. `Publish release branch`
 
 ### Promote Production
 
@@ -226,7 +227,7 @@ The production promotion workflow is also manual.
 
 It resolves the requested or latest official GitHub release and updates the production Argo CD application to that release image pair.
 
-`tradelab-prod` stays in the Argo root application set at all times. It always renders the current `master` deployment manifests, and the manual workflow only advances the pinned release image tags.
+`tradelab-prod` stays in the Argo root application set at all times. It renders the selected `release/<tag>` branch, and the manual workflow advances both the release branch target and the pinned release image tags together.
 
 ### Publish Master Images
 

--- a/docs/infrastructure-bootstrap.md
+++ b/docs/infrastructure-bootstrap.md
@@ -117,4 +117,4 @@ After bootstrap, confirm:
 
 ## Next step
 
-Once this platform layer is healthy, the next TradeLab step is to let `tradelab-dev` follow `master`, trigger manual releases from GitHub Actions, and use the production-promotion workflow to advance `tradelab-prod` to an official release tag.
+Once this platform layer is healthy, the next TradeLab step is to let `tradelab-dev` follow `master`, trigger manual releases from GitHub Actions, and use the production-promotion workflow to advance `tradelab-prod` to the matching official `release/<tag>` branch and release images.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -18,7 +18,7 @@ Recommended operator flow:
 2. if the development publish step for the current `master` state was missed, manually dispatch `Publish Master Images` with `source_ref=master`
 3. verify that the bot-authored development-target PR was created and merged, or if the workflow emitted a warning instead, enable Actions PR creation or provide `AUTOMATION_GITHUB_TOKEN` and open the compare URL it reported
 4. trigger the `Release` workflow from `master`
-5. confirm the GitHub Release and immutable images were published
+5. confirm the GitHub Release, immutable images, and matching `release/<tag>` branch were published
 6. trigger `Promote Production` when production should move to the newest official release
 
 ## Release stages
@@ -29,6 +29,7 @@ Recommended operator flow:
 4. backend and frontend images are published to GHCR
 5. immutable Kubernetes manifests are rendered and packaged
 6. a GitHub Release is created with the generated artifacts
+7. a matching `release/<tag>` branch is published from the released source commit
 
 ## Published artifacts
 
@@ -52,13 +53,21 @@ TradeLab publishes two image classes:
   - `latest`
   - `v0.1.<run-number>`
 
-`tradelab-dev` should use immutable `master-<shortsha>` image tags through its Argo CD application manifest. `tradelab-prod` should use immutable official release tags while rendering the current production manifests from `master`.
+`tradelab-dev` should use immutable `master-<shortsha>` image tags through its Argo CD application manifest. `tradelab-prod` should use immutable official release tags while rendering production manifests from the matching `release/<tag>` branch.
+
+## Release branches
+
+Each official release now also creates a matching release branch:
+
+- `release/v0.1.<run-number>`
+
+That branch is the immutable GitOps source for the production Argo CD application. It keeps production manifests tied to the released source tree instead of whatever happens to be on `master` later.
 
 ## Environment policy
 
 - `tradelab-dev` always follows `master`
-- `tradelab-prod` is promoted only to official GitHub release image tags
-- production promotion is handled by the `Promote Production` workflow, which updates the always-present Argo CD production application to the selected or latest published release
+- `tradelab-prod` follows the selected `release/<tag>` branch plus the matching official release image tags
+- production promotion is handled by the `Promote Production` workflow, which updates the always-present Argo CD production application to the selected or latest published release branch and image tags
 
 ## What a release signals
 

--- a/docs/system-operations.md
+++ b/docs/system-operations.md
@@ -37,7 +37,7 @@ TradeLab currently consists of these runtime components:
 
 - Kubernetes namespace: `tradelab`
 - image tags in release manifests: immutable release tag such as `v0.1.<run-number>`
-- Argo CD source revision: latest promoted official release tag
+- Argo CD source revision: corresponding promoted `release/<tag>` branch
 - database secret source: generated bootstrap secret by default, or external secrets through the optional production-external-secrets overlay
 - intended for controlled deployment via Argo CD promotion after a manual release
 
@@ -111,6 +111,7 @@ TradeLab uses a PR-first delivery model:
    - publishes GHCR images
    - renders immutable Kubernetes release manifests
    - creates a GitHub Release
+   - publishes the matching `release/<tag>` branch
 
 ## GitHub Actions sequence
 
@@ -177,7 +178,7 @@ It:
 2. updates [tradelab-prod.yaml](../deploy/infrastructure/applications/tradelab-prod.yaml)
 3. commits the promotion change back to `master`
 
-`tradelab-prod` is always part of the Argo CD root application set. It always renders the current `master` deployment manifests, while the promotion workflow only advances the pinned backend and frontend image tags to the selected official release. That keeps production on released artifacts without depending on older tagged manifest trees.
+`tradelab-prod` is always part of the Argo CD root application set. It renders the selected `release/<tag>` deployment branch, while the promotion workflow advances both the pinned backend/frontend image tags and the Argo `targetRevision` together. That keeps production on released artifacts without depending on mutable `master`.
 
 This means the effective repository delivery path is:
 


### PR DESCRIPTION
## Summary
- create and publish a matching elease/<tag> branch during the manual release workflow
- make Promote Production update 	radelab-prod to the selected release branch plus matching image tags
- align release and operations docs with the new production GitOps source

Closes #137.